### PR TITLE
adding experimental add wins set

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
         "version" : "1.0.3"
       }
+    },
+    {
+      "identity" : "swiftcbor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/valpackett/SwiftCBOR",
+      "state" : {
+        "revision" : "98a59c305cca5c5367c3422d5e127661d4e76e24",
+        "version" : "0.4.5"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,14 @@ let package = Package(
         .library(
             name: "DittoExportLogs",
             targets: ["DittoExportLogs"]),
+        .library(
+            name: "DittoAddWinsSet",
+            targets: ["DittoAddWinsSet"]),
     ],
     dependencies: [
         .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "3.0.0"),
-        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
+        .package(url: "https://github.com/valpackett/SwiftCBOR", from: "0.4.5")
     ],
     targets: [
         .target(
@@ -39,7 +43,6 @@ let package = Package(
                 .define("ENABLE_BITCODE", to: "NO")
             ]
         ),
-        
         .target(
             name: "DittoDataBrowser",
             dependencies: [
@@ -48,7 +51,19 @@ let package = Package(
             ],
             path: "Sources/DittoDataBrowser"
         ),
-        
+        .target(
+            name: "DittoAddWinsSet",
+            dependencies: [
+                .product(name: "DittoSwift", package: "DittoSwiftPackage"),
+                .product(name: "SwiftCBOR", package: "SwiftCBOR")
+            ],
+            path: "Sources/DittoAddWinsSet"
+        ),
+        .testTarget(
+            name: "DittoAddWinsSetTests",
+            dependencies: ["DittoAddWinsSet"],
+            path: "Tests/DittoAddWinsSet"
+        ),
         .target(
             name: "DittoExportLogs",
             dependencies: [

--- a/Sources/DittoAddWinsSet/DittoAddWinsSet.swift
+++ b/Sources/DittoAddWinsSet/DittoAddWinsSet.swift
@@ -21,7 +21,7 @@ public struct DittoAddWinsSet {
     func asDictionary() throws -> [String: Any?] {
         var dictionary: [String: Any?] = [:]
         for v in values {
-            let bytes = try SwiftCBOR.CBOR.encodeAny(v)
+            let bytes = (try SwiftCBOR.CBOR.encodeAny(v)).sorted()
             let data = Data(bytes)
             dictionary[data.base64EncodedString()] = v
         }
@@ -46,4 +46,9 @@ extension DittoDocumentPath {
 
 }
 
+extension DittoMutableDocumentPath {
+    func set(_ addWinsSet: DittoAddWinsSet, isDefault: Bool = false) throws{
+        self.set(try addWinsSet.asDictionary())
+    }
+}
 

--- a/Sources/DittoAddWinsSet/DittoAddWinsSet.swift
+++ b/Sources/DittoAddWinsSet/DittoAddWinsSet.swift
@@ -1,0 +1,49 @@
+//
+//  File.swift
+//  
+//
+//  Created by Maximilian Alexander on 1/29/23.
+//
+
+import Foundation
+import DittoSwift
+import SwiftCBOR
+
+public struct DittoAddWinsSet {
+
+    public var values: Set<AnyHashable?>
+
+    init(dictionary: [String: Any?]) {
+        let hashableValues = dictionary.values.map({ $0 as? AnyHashable })
+        self.values = Set(hashableValues)
+    }
+
+    func asDictionary() throws -> [String: Any?] {
+        var dictionary: [String: Any?] = [:]
+        for v in values {
+            let bytes = try SwiftCBOR.CBOR.encodeAny(v)
+            let data = Data(bytes)
+            dictionary[data.base64EncodedString()] = v
+        }
+        return dictionary
+    }
+
+    mutating func insert(_ value: AnyHashable) {
+        self.values.insert(value)
+    }
+
+    mutating func remove(_ value: AnyHashable) {
+        self.values.remove(value)
+    }
+}
+
+extension DittoDocumentPath {
+
+    var addWinsSet: DittoAddWinsSet? {
+        guard let dictionary = dictionary else { return nil }
+        return DittoAddWinsSet(dictionary: dictionary)
+    }
+
+}
+
+

--- a/Sources/DittoDataBrowser/DataBrowser.swift
+++ b/Sources/DittoDataBrowser/DataBrowser.swift
@@ -5,6 +5,9 @@
 //  Created by Walker Erekson on 11/3/22.
 //
 
+#if canImport(UIKit)
+#if canImport(SwiftUI)
+
 import SwiftUI
 import DittoSwift
 
@@ -34,3 +37,5 @@ public struct DataBrowser: View {
         }
     }
 }
+#endif
+#endif

--- a/Sources/DittoDataBrowser/Documents.swift
+++ b/Sources/DittoDataBrowser/Documents.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 import DittoSwift
 
+#if canImport(SwiftUI)
+#if canImport(UIKit)
+
+import UIKit
+
 @available(iOS 15.0, *)
 struct Documents: View {
     
@@ -140,3 +145,5 @@ struct SearchBar: View {
         }
     }
 }
+#endif
+#endif

--- a/Sources/DittoExportLogs/ExportLogs.swift
+++ b/Sources/DittoExportLogs/ExportLogs.swift
@@ -1,5 +1,7 @@
 import DittoSwift
 import SwiftUI
+
+#if canImport(UIKit)
 import UIKit
 
 
@@ -38,3 +40,4 @@ public struct ExportLogs: UIViewControllerRepresentable {
 }
 
 
+#endif

--- a/Tests/DittoAddWinsSet/ConstructorTests.swift
+++ b/Tests/DittoAddWinsSet/ConstructorTests.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  
+//
+//  Created by Maximilian Alexander on 1/30/23.
+//
+
+import XCTest
+@testable import DittoAddWinsSet
+
+class ConstructorTests: XCTestCase {
+
+    func testSetDeDuplication() throws {
+        let addWinsSet = DittoAddWinsSet(dictionary: [
+            "foo": "bar",
+            "1": 20,
+            "2": 20,
+            "zoo": "bar",
+        ])
+        XCTAssertEqual(addWinsSet.values.count, 2)
+        let dictionary = try addWinsSet.asDictionary()
+        print(dictionary.keys)
+        XCTAssertEqual(dictionary.count, 2)
+    }
+
+    func testComplexSetDuplicationWithMaps() {
+        let addWinsSet = DittoAddWinsSet(dictionary: [
+            "foo": ["a": 1],
+            "1": 20,
+            "2": 20,
+            "zoo": ["a": 1],
+        ])
+        XCTAssertEqual(addWinsSet.values.count, 2)
+    }
+    
+    func testComplexSetDuplicationWithArrays() {
+        let addWinsSet = DittoAddWinsSet(dictionary: [
+            "foo": [1, 2],
+            "1": 20,
+            "2": 20,
+            "zoo": [1, 3],
+        ])
+        XCTAssertEqual(addWinsSet.values.count, 3)
+    }
+}

--- a/Tests/DittoAddWinsSet/ConstructorTests.swift
+++ b/Tests/DittoAddWinsSet/ConstructorTests.swift
@@ -25,10 +25,10 @@ class ConstructorTests: XCTestCase {
 
     func testComplexSetDuplicationWithMaps() {
         let addWinsSet = DittoAddWinsSet(dictionary: [
-            "foo": ["a": 1],
+            "foo": ["a": 1, "b": 1],
             "1": 20,
             "2": 20,
-            "zoo": ["a": 1],
+            "zoo": ["b": 1, "a": 1],
         ])
         XCTAssertEqual(addWinsSet.values.count, 2)
     }


### PR DESCRIPTION
adding experimental add wins set. Not very efficient but gets the idea across

1. Values are duplicated and
2. Keys are base64Encoded of `[Uint8]` CBOR of the values

## Concerns

CBOR key ordering is non-ordered, so I sorted the bytes after encoding