### PR TITLE
✨ Add `DittoDiskUsage` library to package and app

### DIFF
--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		0E1252B72951114B00BCC55E /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = 0E1252B62951114B00BCC55E /* DittoDataBrowser */; };
 		0E1252B92951114B00BCC55E /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = 0E1252B82951114B00BCC55E /* DittoPresenceViewer */; };
 		0EBA54E0298836C600083183 /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 0EBA54DF298836C600083183 /* DittoExportLogs */; };
+		F87DC47C2988584200899FEC /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47B2988584200899FEC /* DittoDataBrowser */; };
+		F87DC47E2988584200899FEC /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47D2988584200899FEC /* DittoExportLogs */; };
+		F87DC4802988584200899FEC /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47F2988584200899FEC /* DittoPresenceViewer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +87,7 @@
 		01F34D0428A31147003BDF17 /* PrimaryFormButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryFormButton.swift; sourceTree = "<group>"; };
 		01F34D0628A3119E003BDF17 /* MenuListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListItem.swift; sourceTree = "<group>"; };
 		01F34D0828A31644003BDF17 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		F87DC4672988501000899FEC /* DittoSwiftTools */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DittoSwiftTools; path = ..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +98,9 @@
 				0E1252B92951114B00BCC55E /* DittoPresenceViewer in Frameworks */,
 				0EBA54E0298836C600083183 /* DittoExportLogs in Frameworks */,
 				0E1252B72951114B00BCC55E /* DittoDataBrowser in Frameworks */,
+				F87DC47E2988584200899FEC /* DittoExportLogs in Frameworks */,
+				F87DC4802988584200899FEC /* DittoPresenceViewer in Frameworks */,
+				F87DC47C2988584200899FEC /* DittoDataBrowser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,6 +124,7 @@
 		01F34C8828A2EAE3003BDF17 = {
 			isa = PBXGroup;
 			children = (
+				F87DC4662988501000899FEC /* Packages */,
 				01F34C9328A2EAE3003BDF17 /* DittoToolsApp */,
 				01F34CA428A2EAE5003BDF17 /* DittoToolsAppTests */,
 				01F34CAE28A2EAE5003BDF17 /* DittoToolsAppUITests */,
@@ -229,6 +237,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		F87DC4662988501000899FEC /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				F87DC47A2988581000899FEC /* DittoSwiftTools */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -249,6 +265,9 @@
 				0E1252B62951114B00BCC55E /* DittoDataBrowser */,
 				0E1252B82951114B00BCC55E /* DittoPresenceViewer */,
 				0EBA54DF298836C600083183 /* DittoExportLogs */,
+				F87DC47B2988584200899FEC /* DittoDataBrowser */,
+				F87DC47D2988584200899FEC /* DittoExportLogs */,
+				F87DC47F2988584200899FEC /* DittoPresenceViewer */,
 			);
 			productName = debug;
 			productReference = 01F34C9128A2EAE3003BDF17 /* DittoToolsApp.app */;
@@ -323,7 +342,6 @@
 			);
 			mainGroup = 01F34C8828A2EAE3003BDF17;
 			packageReferences = (
-				0E1252B52951114B00BCC55E /* XCRemoteSwiftPackageReference "DittoSwiftTools" */,
 			);
 			productRefGroup = 01F34C9228A2EAE3003BDF17 /* Products */;
 			projectDirPath = "";
@@ -544,7 +562,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"DittoToolsApp/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "DittoToolsApp/Preview\\ Content";
 				DEVELOPMENT_TEAM = 3T2VMFZPPQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -578,7 +596,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"DittoToolsApp/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "DittoToolsApp/Preview\\ Content";
 				DEVELOPMENT_TEAM = 3T2VMFZPPQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -722,26 +740,20 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		0E1252B52951114B00BCC55E /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
 		0E1252B62951114B00BCC55E /* DittoDataBrowser */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0E1252B52951114B00BCC55E /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+		F87DC47B2988584200899FEC /* DittoDataBrowser */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = DittoDataBrowser;
 		};
-		0E1252B82951114B00BCC55E /* DittoPresenceViewer */ = {
+		F87DC47D2988584200899FEC /* DittoExportLogs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0E1252B52951114B00BCC55E /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoExportLogs;
+		};
+		F87DC47F2988584200899FEC /* DittoPresenceViewer */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = DittoPresenceViewer;
 		};
 		0EBA54DF298836C600083183 /* DittoExportLogs */ = {

--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		F87DC47C2988584200899FEC /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47B2988584200899FEC /* DittoDataBrowser */; };
 		F87DC47E2988584200899FEC /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47D2988584200899FEC /* DittoExportLogs */; };
 		F87DC4802988584200899FEC /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47F2988584200899FEC /* DittoPresenceViewer */; };
+		F87DC481298858EC00899FEC /* DiskUsageViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87DC46F298854E600899FEC /* DiskUsageViewer.swift */; };
+		F87DC4832988599C00899FEC /* DittoDiskUsage in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC4822988599C00899FEC /* DittoDiskUsage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,7 +89,8 @@
 		01F34D0428A31147003BDF17 /* PrimaryFormButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryFormButton.swift; sourceTree = "<group>"; };
 		01F34D0628A3119E003BDF17 /* MenuListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListItem.swift; sourceTree = "<group>"; };
 		01F34D0828A31644003BDF17 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		F87DC4672988501000899FEC /* DittoSwiftTools */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DittoSwiftTools; path = ..; sourceTree = "<group>"; };
+		F87DC46F298854E600899FEC /* DiskUsageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskUsageViewer.swift; sourceTree = "<group>"; };
+		F87DC47A2988581000899FEC /* DittoSwiftTools */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DittoSwiftTools; path = ..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +103,7 @@
 				0E1252B72951114B00BCC55E /* DittoDataBrowser in Frameworks */,
 				F87DC47E2988584200899FEC /* DittoExportLogs in Frameworks */,
 				F87DC4802988584200899FEC /* DittoPresenceViewer in Frameworks */,
+				F87DC4832988599C00899FEC /* DittoDiskUsage in Frameworks */,
 				F87DC47C2988584200899FEC /* DittoDataBrowser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -212,10 +216,11 @@
 			isa = PBXGroup;
 			children = (
 				016757D828A32E9400347491 /* CollectionView.swift */,
-				01F34CEF28A30E88003BDF17 /* NetworkPage.swift */,
-				01F34CF628A30F5E003BDF17 /* DataBrowser.swift */,
-				01F34D0128A310A5003BDF17 /* Login.swift */,
 				01F34C9628A2EAE3003BDF17 /* ContentView.swift */,
+				01F34CF628A30F5E003BDF17 /* DataBrowser.swift */,
+				F87DC46F298854E600899FEC /* DiskUsageViewer.swift */,
+				01F34D0128A310A5003BDF17 /* Login.swift */,
+				01F34CEF28A30E88003BDF17 /* NetworkPage.swift */,
 				016757DC28A3313300347491 /* PresenceViewer.swift */,
 			);
 			path = Pages;
@@ -268,6 +273,7 @@
 				F87DC47B2988584200899FEC /* DittoDataBrowser */,
 				F87DC47D2988584200899FEC /* DittoExportLogs */,
 				F87DC47F2988584200899FEC /* DittoPresenceViewer */,
+				F87DC4822988599C00899FEC /* DittoDiskUsage */,
 			);
 			productName = debug;
 			productReference = 01F34C9128A2EAE3003BDF17 /* DittoToolsApp.app */;
@@ -403,6 +409,7 @@
 				01F34CE228A30781003BDF17 /* MainThreadMonitor.swift in Sources */,
 				01F34D0928A31644003BDF17 /* AppDelegate.swift in Sources */,
 				016757DF28A3393B00347491 /* Config.swift in Sources */,
+				F87DC481298858EC00899FEC /* DiskUsageViewer.swift in Sources */,
 				016757D928A32E9400347491 /* CollectionView.swift in Sources */,
 				01F34D0528A31147003BDF17 /* PrimaryFormButton.swift in Sources */,
 			);
@@ -760,6 +767,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0E1252B52951114B00BCC55E /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
 			productName = DittoExportLogs;
+		};
+		F87DC4822988599C00899FEC /* DittoDiskUsage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoDiskUsage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,17 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "63caac018345b42985749618b43d1a7e725bbeaa",
-        "version" : "3.0.1"
-      }
-    },
-    {
-      "identity" : "dittoswifttools",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getditto/DittoSwiftTools",
-      "state" : {
-        "branch" : "main",
-        "revision" : "e2334b68286cc68a2e21db1a96f65b0abfd7d277"
+        "revision" : "cd88e8bd18ac64169a680ee5227a0dbaaea7e914",
+        "version" : "3.0.4"
       }
     },
     {

--- a/DittoToolsApp/DittoToolsApp/DittoManager.swift
+++ b/DittoToolsApp/DittoToolsApp/DittoManager.swift
@@ -13,7 +13,7 @@ class AuthDelegate: DittoAuthenticationDelegate {
         print("login with \(token), \(provider)")
     
         authenticator.loginWithToken(token, provider: provider, completion: { err in
-            print("Error authenticating \(err?.localizedDescription)")
+            print("Error authenticating \(String(describing: err?.localizedDescription))")
         })
     }
 
@@ -22,7 +22,7 @@ class AuthDelegate: DittoAuthenticationDelegate {
         let token = DittoManager.shared.config.authenticationToken
         print("Auth token expiring in \(secondsRemaining)")
         authenticator.loginWithToken(token, provider: provider, completion: { err in
-            print("Error authenticating \(err?.localizedDescription)")
+            print("Error authenticating \(String(describing: err?.localizedDescription))")
         })
     }
 }

--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -58,7 +58,11 @@ struct ContentView: View {
                         ExportLogs()
                     }
                 }
-                
+                Section(header: Text("Disk Usage")) {
+                    NavigationLink(destination: DiskUsageViewer()) {
+                        MenuListItem(title: "Disk Usage", systemImage: "opticaldiscdrive", color: .green)
+                    }
+                }
             }
             .listStyle(InsetGroupedListStyle())
             .navigationTitle("Ditto Tools")

--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -41,6 +41,9 @@ struct ContentView: View {
                     NavigationLink(destination: PresenceViewer()) {
                         MenuListItem(title: "Presence Viewer", systemImage: "network", color: .green)
                     }
+                    NavigationLink(destination: DiskUsageViewer()) {
+                        MenuListItem(title: "Disk Usage", systemImage: "opticaldiscdrive", color: .green)
+                    }
                 }
                 Section(header: Text("Configuration")) {
                     NavigationLink(destination: Login()) {
@@ -56,11 +59,6 @@ struct ContentView: View {
                     .foregroundColor(.black)
                     .sheet(isPresented: $exportLogsSheet) {
                         ExportLogs()
-                    }
-                }
-                Section(header: Text("Disk Usage")) {
-                    NavigationLink(destination: DiskUsageViewer()) {
-                        MenuListItem(title: "Disk Usage", systemImage: "opticaldiscdrive", color: .green)
                     }
                 }
             }
@@ -86,7 +84,7 @@ struct ContentView: View {
                 }
         })
         VStack {
-            Text("SDK Version: \(dittoModel.ditto!.sdkVersion ?? "N/A")")
+            Text("SDK Version: \(dittoModel.ditto?.sdkVersion ?? "N/A")")
         }.padding()
 }
 }

--- a/DittoToolsApp/DittoToolsApp/Pages/DiskUsageViewer.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/DiskUsageViewer.swift
@@ -1,0 +1,17 @@
+//
+//  DiskUsageViewer.swift
+//  DittoToolsApp
+//
+//  Created by Ben Chatelain on 2023-01-30.
+//
+
+import DittoDiskUsage
+import SwiftUI
+
+struct DiskUsageViewer: View {
+
+    var body: some View {
+        DittoDiskUsageView(ditto: DittoManager.shared.ditto!)
+        EmptyView()
+    }
+}

--- a/DittoToolsApp/DittoToolsApp/Pages/PresenceViewer.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/PresenceViewer.swift
@@ -1,11 +1,12 @@
 //
 //  Copyright © 2022 DittoLive Incorporated. All rights reserved.
 //
+
 import SwiftUI
 import UIKit
 import DittoPresenceViewer
 
-struct PresenceViewer: View{
+struct PresenceViewer: View {
 
     var body: some View {
         PresenceView(ditto: DittoManager.shared.ditto!)

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "0f41078a6a7441cc56c6be952fa6bcd85b4e0199",
-        "version" : "3.0.0"
+        "revision" : "cd88e8bd18ac64169a680ee5227a0dbaaea7e914",
+        "version" : "3.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,9 @@ let package = Package(
         .library(
             name: "DittoExportLogs",
             targets: ["DittoExportLogs"]),
+        .library(
+            name: "DittoDiskUsage",
+            targets: ["DittoDiskUsage"]),
     ],
     dependencies: [
         // Ditto.diskUsage was added in 3.0.1
@@ -56,6 +59,14 @@ let package = Package(
                 .product(name: "DittoSwift", package: "DittoSwiftPackage")
             ],
             path: "Sources/DittoExportLogs"
+        ),
+
+        .target(
+            name: "DittoDiskUsage",
+            dependencies: [
+                .product(name: "DittoSwift", package: "DittoSwiftPackage")
+            ],
+            path: "Sources/DittoDiskUsage"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
             targets: ["DittoExportLogs"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "3.0.0"),
+        // Ditto.diskUsage was added in 3.0.1
+        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "3.0.1"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
     ],
     targets: [
@@ -48,7 +49,7 @@ let package = Package(
             ],
             path: "Sources/DittoDataBrowser"
         ),
-        
+
         .target(
             name: "DittoExportLogs",
             dependencies: [

--- a/Sources/DittoDataBrowser/Documents.swift
+++ b/Sources/DittoDataBrowser/Documents.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 import DittoSwift
 
+#if canImport(UIKit)
+import UIKit
+#endif
+
 @available(iOS 15.0, *)
 struct Documents: View {
     

--- a/Sources/DittoDiskUsage/DittoDiskUsageView.swift
+++ b/Sources/DittoDiskUsage/DittoDiskUsageView.swift
@@ -1,0 +1,165 @@
+//
+//  DittoDiskUsageView.swift
+//  DittoSwiftTools/DiskUsage
+//
+//  Created by Ben Chatelain on 2023-01-30.
+//
+
+import DittoSwift
+import SwiftUI
+import Combine
+
+fileprivate struct DiskUsage: Hashable {
+    let relativePath: String
+    let sizeInBytes: Int
+    let size: String
+}
+
+fileprivate struct DiskUsageState {
+    let rootPath: String
+    let totalSizeInBytes: Int
+    let totalSize: String
+    let children: [DiskUsage]
+    let lastUpdated: String
+    let error: String?
+}
+
+@available(iOS 14, *)
+class DiskUsageViewModel: ObservableObject {
+
+    @Published fileprivate var diskUsage: DiskUsageState?
+    var cancellable: Cancellable?
+
+    /// Convenience property for Ditto instance.
+    private var ditto: Ditto
+
+    /// Formats file sizes like:
+    /// - 248 bytes
+    /// - 58 KB
+    /// - 4.2 MB
+    private static let byteCountFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter
+    }()
+
+    /// Formats times like: 12:38:45 PM
+    static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+
+    /// Uses `byteCountFormatter` to create a human-readable string.
+    private func formatBytes(bytes: Int) -> String {
+        guard let formattedSize = DiskUsageViewModel.byteCountFormatter.string(for: bytes) else { return "error" }
+        return formattedSize
+    }
+
+    init(ditto: Ditto) {
+        self.ditto = ditto
+        cancellable = ditto.diskUsage
+            .diskUsagePublisher()
+            .map { diskUsage in
+                let children = diskUsage.childItems
+                    .map { (child: DiskUsageItem) in
+                        DiskUsage(
+                            relativePath: child.path,
+                            sizeInBytes: child.sizeInBytes,
+                            size: DiskUsageViewModel.byteCountFormatter.string(for: child.sizeInBytes) ?? "error"
+                        )
+                    }
+                    .sorted { $0.relativePath < $1.relativePath }
+
+                return DiskUsageState(
+                    rootPath: diskUsage.path,
+                    totalSizeInBytes: diskUsage.sizeInBytes,
+                    totalSize: DiskUsageViewModel.byteCountFormatter.string(for: diskUsage.sizeInBytes) ?? "error",
+                    children: children,
+                    lastUpdated: DiskUsageViewModel.dateFormatter.string(from: Date()),
+                    error: nil
+                )
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.diskUsage, on: self)
+    }
+}
+
+@available(iOS 14, *)
+public struct DittoDiskUsageView: View {
+
+    @Environment(\.presentationMode) var presentationMode
+
+    var ditto: Ditto
+
+    @ObservedObject var viewModel: DiskUsageViewModel
+
+    init(ditto: Ditto) {
+        self.ditto = ditto
+        self.viewModel = DiskUsageViewModel(ditto: ditto)
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                Text("Disk Usage")
+                    .frame(width: 400, alignment: .center)
+                    .font(.title)
+            }
+
+            Section {
+                if let diskUsage = viewModel.diskUsage {
+                    if let error = diskUsage.error {
+                        Text("Error: \(error)")
+                            .foregroundColor(.red)
+                    } else {
+                        ForEach(diskUsage.children, id: \.self) { (child: DiskUsage) in
+                            HStack {
+                                Text(child.relativePath)
+                                    .frame(width: 200, alignment: .leading)
+                                Text(child.size)
+                                    .frame(width: 100, alignment: .trailing)
+                            }
+                        }
+                        HStack {
+                            Group {
+                                Text("Total")
+                                    .frame(width: 200, alignment: .leading)
+                                Text(diskUsage.totalSize)
+                                    .frame(width: 100, alignment: .trailing)
+                            }
+                        }
+                    }
+                } else {
+                    // Displayed before first async callback
+                    Text("Calculating disk usage 💾⏳")
+                }
+            }
+
+            Section {
+                HStack {
+                    Text("Updated at:")
+                        .frame(width: 200, alignment: .leading)
+                    Text(viewModel.diskUsage?.lastUpdated ?? DiskUsageViewModel.dateFormatter.string(from: Date()))
+                        .frame(width: 100, alignment: .trailing)
+                }
+            }
+
+            Section {
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    // Label was added in iOS 14
+                    Label("Close", systemImage: "xmark")
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 14, *)
+struct DittoDiskUsageView_Previews: PreviewProvider {
+    static var previews: some View {
+        DittoDiskUsageView(ditto: Ditto())
+    }
+}

--- a/Sources/DittoDiskUsage/DittoDiskUsageView.swift
+++ b/Sources/DittoDiskUsage/DittoDiskUsageView.swift
@@ -94,7 +94,7 @@ public struct DittoDiskUsageView: View {
 
     @ObservedObject var viewModel: DiskUsageViewModel
 
-    init(ditto: Ditto) {
+    public init(ditto: Ditto) {
         self.ditto = ditto
         self.viewModel = DiskUsageViewModel(ditto: ditto)
     }


### PR DESCRIPTION
Resolves #4

I replaced the reference in the DittoToolsApp to the `main` branch of this repo with a local package reference. This way the app is always using the same branch as the package, plus any local changes. This allows for immediate use of changes to the package so we can test changes.

Also, I upped the minimum version of `DittoSwift` to `3.0.1` as that was when the `diskUsage` property was added to the `Ditto` class. 

## 📸 Screenshots

<img src="https://user-images.githubusercontent.com/28851/215586339-3a493bc5-5369-4d40-8569-db47eb99797d.png" alt="Ditto Tools app showing new Disk Usage menu item" width="350"> <img src="https://user-images.githubusercontent.com/28851/215583306-24cc6680-fa53-46b5-9396-04167fe3953d.png" alt="Disk Usage screen" width="350">