### PR TITLE
DittoToolsApp: esthetic updates to ExportData feature 

### DIFF
--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
         func stopSync() {
         }
     }
-
+    @Environment(\.colorScheme) private var colorScheme
     @ObservedObject private var viewModel = ViewModel()
     @ObservedObject private var dittoModel = DittoManager.shared
 
@@ -33,32 +33,36 @@ struct ContentView: View {
     @State private var presentExportDataShare: Bool = false
     @State private var presentExportDataAlert: Bool = false
 
+    private var textColor: Color {
+        colorScheme == .dark ? .white : .black
+    }
+    
     var body: some View {
         NavigationView {
             List{
                 Section(header: Text("Debug")) {
                     NavigationLink(destination: DataBrowserView()) {
-                        MenuListItem(title: "Data Browser", systemImage: "photo", color: .green)
+                        MenuListItem(title: "Data Browser", systemImage: "photo", color: .orange)
                     }
                     if #available(iOS 15, *) {
                         NavigationLink(destination: PeersListViewer()) {
-                            MenuListItem(title: "Peers List", systemImage: "network", color: .green)
+                            MenuListItem(title: "Peers List", systemImage: "network", color: .blue)
                         }
                     } else {
                         NavigationLink(destination: NetworkPage()) {
-                            MenuListItem(title: "Peers List", systemImage: "network", color: .green)
+                            MenuListItem(title: "Peers List", systemImage: "network", color: .blue)
                         }
                     }
                     NavigationLink(destination: PresenceViewer()) {
-                        MenuListItem(title: "Presence Viewer", systemImage: "network", color: .green)
+                        MenuListItem(title: "Presence Viewer", systemImage: "network", color: .pink)
                     }
                     NavigationLink(destination: DiskUsageViewer()) {
-                        MenuListItem(title: "Disk Usage", systemImage: "opticaldiscdrive", color: .green)
+                        MenuListItem(title: "Disk Usage", systemImage: "opticaldiscdrive", color: .secondary)
                     }
                 }
                 Section(header: Text("Configuration")) {
                     NavigationLink(destination: Login()) {
-                        MenuListItem(title: "Change Identity", systemImage: "envelope", color: .green)
+                        MenuListItem(title: "Change Identity", systemImage: "envelope", color: .purple)
                     }
                 }
                 Section(header: Text("Exports")) {
@@ -66,9 +70,13 @@ struct ContentView: View {
                     Button(action: {
                         self.presentExportLogsAlert.toggle()
                     }) {
-                        MenuListItem(title: "Export Logs", systemImage: "square.and.arrow.up", color: .green)
+                        HStack {
+                            MenuListItem(title: "Export Logs", systemImage: "square.and.arrow.up", color: .green)
+                            Spacer()
+                        }
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(textColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .sheet(isPresented: $presentExportLogsShare) {
                         ExportLogs()
                     }
@@ -77,14 +85,16 @@ struct ContentView: View {
                     Button(action: {
                         self.presentExportDataAlert.toggle()
                     }) {
-                        MenuListItem(title: "Export Data Directory", systemImage: "square.and.arrow.up", color: .green)
+                        HStack {
+                            MenuListItem(title: "Export Data Directory", systemImage: "square.and.arrow.up", color: .green)
+                            Spacer()
+                        }
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(textColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .sheet(isPresented: $presentExportDataShare) {
                         ExportData(ditto: dittoModel.ditto!)
                     }
-
-
                 }
             }
             .listStyle(InsetGroupedListStyle())
@@ -107,7 +117,7 @@ struct ContentView: View {
                 Button("Cancel", role: .cancel) {}
 
                 } message: {
-                    Text("Compressing the logs may take a while.")
+                    Text("Compressing the data may take a while.")
                 }
             }
             
@@ -121,7 +131,7 @@ struct ContentView: View {
         VStack {
             Text("SDK Version: \(dittoModel.ditto?.sdkVersion ?? "N/A")")
         }.padding()
-}
+    }
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/DittoToolsApp/DittoToolsApp/Views/MenuListItem.swift
+++ b/DittoToolsApp/DittoToolsApp/Views/MenuListItem.swift
@@ -42,16 +42,22 @@ struct MenuListItem_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView{
             List {
-                Section {
-                    MenuListItem(title: "Work Orders", systemImage: "doc.append", color: .orange)
-                    MenuListItem(title: "Requests", systemImage: "hand.raised", color: .blue)
-                    MenuListItem(title: "Location", systemImage: "map", color: .pink)
-                    MenuListItem(title: "Assets", systemImage: "shippingbox", color: .secondary)
-                    MenuListItem(title: "Meter Readings", systemImage: "speedometer", color: .purple)
+                Section("Debug") {
+                    MenuListItem(title: "Data Browser", systemImage: "photo", color: .orange)
+                    MenuListItem(title: "Peers List", systemImage: "network", color: .blue)
+                    MenuListItem(title: "Presence Viewer", systemImage: "network", color: .pink)
+                    MenuListItem(title: "Disk Usage", systemImage: "opticaldiscdrive", color: .secondary)
+                }
+                Section("Change Identity") {
+                    MenuListItem(title: "Change Identity", systemImage: "envelope", color: .purple)
+                }
+                Section("Exports") {
+                    MenuListItem(title: "Export Logs", systemImage: "square.and.arrow.up", color: .green)
+                    MenuListItem(title: "Export Logs", systemImage: "square.and.arrow.up", color: .green)
                 }
             }
             .listStyle(GroupedListStyle())
-            .navigationTitle("Pluto")
+            .navigationTitle("DittoTools")
         }
         .preferredColorScheme(.dark)
     }

--- a/Sources/DittoExportData/ExportData.swift
+++ b/Sources/DittoExportData/ExportData.swift
@@ -32,7 +32,7 @@ public struct ExportData: UIViewControllerRepresentable {
 
     private func zipDittoDirectory() -> URL? {
 
-        let destinationURL = fileManager.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).zip")
+        let destinationURL = fileManager.temporaryDirectory.appendingPathComponent("DittoData.zip")
 
         try? FileManager().removeItem(at: destinationURL)
 

--- a/Sources/DittoExportLogs/DittoLogManager.swift
+++ b/Sources/DittoExportLogs/DittoLogManager.swift
@@ -10,7 +10,7 @@ import Foundation
 private struct Config {
     static let logsDirectoryName = "debug-logs"
     static let logFileName = "logs.txt"
-    static let zippedLogFileName = "logs.zip"
+    static let zippedLogFileName = "DittoLogs.zip"
 
     static var logsDirectory: URL! = {
         let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!


### PR DESCRIPTION
- make export buttons text in contentView list darkmode-safe; enlarge tapping area  
- change data export file name from long random UUID to `DittoData.zip`; tested that  
  existing zip file in tmp is replaced each time  
- change logs export file name from `logs.zip` to `DittoLogs.zip`  
- update MenuListItem.swift preview and ContentView list item styles to match  