### PR TITLE
DittoToolsApp: Ditto log level user setting feature in Login

### DIFF
--- a/DittoToolsApp/DittoToolsApp/Model/Config.swift
+++ b/DittoToolsApp/DittoToolsApp/Model/Config.swift
@@ -5,7 +5,9 @@
 //  Created by Rae McKelvey on 8/9/22.
 //
 
+import DittoSwift
 import Foundation
+
 
 struct DittoConfig {
     var appID = ""
@@ -16,3 +18,5 @@ struct DittoConfig {
     var authenticationToken = ""
     var useIsolatedDirectories = true
 }
+
+

--- a/DittoToolsApp/DittoToolsApp/Pages/Login.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/Login.swift
@@ -10,6 +10,7 @@ struct Login: View {
         var error: String = ""
         @Published var useIsolatedDirectories = true
         @Published var config = DittoConfig()
+        @Published var logLevel: AppSettings.LogLevel = AppSettings.shared.logLevel
         
         init () {
             self.config = dittoModel.config
@@ -28,6 +29,10 @@ struct Login: View {
                 self.isPresentingAlert = true
                 self.error = err.localizedDescription
             }
+        }
+        
+        func setLoggingLevel() {
+            AppSettings.shared.logLevel = self.logLevel
         }
     }
     
@@ -71,8 +76,17 @@ struct Login: View {
                     }
                 }
                 Section {
+                    Picker("Logging Level", selection: $viewModel.logLevel) {
+                        ForEach(AppSettings.LogLevel.allCases, id: \.self) { loggingOption in
+                            Text(loggingOption.description).tag(loggingOption)
+                        }
+                    }
+                }
+                Section {
                     PrimaryFormButton(action: {
+                        viewModel.setLoggingLevel()
                         viewModel.changeIdentity()
+                        dismiss()
                     }, text: "Restart Ditto", textColor: viewModel.isDisabled ? .secondary : .accentColor, isLoading: false, isDisabled: false)
                 }
             }
@@ -87,10 +101,8 @@ struct Login: View {
             }) */
             .alert("Ditto failed to start.", isPresented: $viewModel.isPresentingAlert, actions: {
                     Button("Dismiss", role: .cancel) { dismiss() }
-                    
                 })
             }
-        
     }
 }
 


### PR DESCRIPTION
This feature enables a user to set the Ditto logging level, or to disable logging, from the Login UI. The setting is stored in UserDefaults.standard when Ditto is restarted, and logging begins at launch from the last stored level; the default is `.disabled`.

- Ditto log level user setting feature in Login
- refactor to consistently use UserDefaults.standard