### PR TITLE
Log level and Export Logs features in new details view

### DIFF
--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		01F34D0728A3119E003BDF17 /* MenuListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F34D0628A3119E003BDF17 /* MenuListItem.swift */; };
 		01F34D0928A31644003BDF17 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F34D0828A31644003BDF17 /* AppDelegate.swift */; };
 		0EBA54E0298836C600083183 /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 0EBA54DF298836C600083183 /* DittoExportLogs */; };
+		142F962A2A268E48000C3664 /* LoggingDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142F96292A268E48000C3664 /* LoggingDetailsView.swift */; };
 		146ED3F629C4F13100A56229 /* DittoPeersList in Frameworks */ = {isa = PBXBuildFile; productRef = 146ED3F529C4F13100A56229 /* DittoPeersList */; };
 		146ED3FA29C4F2A000A56229 /* PeersListViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146ED3F929C4F2A000A56229 /* PeersListViewer.swift */; };
 		CC80DC002A1EACCE004A2A65 /* DittoExportData in Frameworks */ = {isa = PBXBuildFile; productRef = CC80DBFF2A1EACCE004A2A65 /* DittoExportData */; };
@@ -89,6 +90,8 @@
 		01F34D0428A31147003BDF17 /* PrimaryFormButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryFormButton.swift; sourceTree = "<group>"; };
 		01F34D0628A3119E003BDF17 /* MenuListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListItem.swift; sourceTree = "<group>"; };
 		01F34D0828A31644003BDF17 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		142ED0E52A2687D3004D1BCB /* LoggingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingDetailView.swift; sourceTree = "<group>"; };
+		142F96292A268E48000C3664 /* LoggingDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingDetailsView.swift; sourceTree = "<group>"; };
 		146ED3F929C4F2A000A56229 /* PeersListViewer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeersListViewer.swift; sourceTree = "<group>"; };
 		F87DC46F298854E600899FEC /* DiskUsageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskUsageViewer.swift; sourceTree = "<group>"; };
 		F87DC47A2988581000899FEC /* DittoSwiftTools */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DittoSwiftTools; path = ..; sourceTree = "<group>"; };
@@ -219,6 +222,7 @@
 				01F34C9628A2EAE3003BDF17 /* ContentView.swift */,
 				01F34CF628A30F5E003BDF17 /* DataBrowser.swift */,
 				F87DC46F298854E600899FEC /* DiskUsageViewer.swift */,
+				142F96292A268E48000C3664 /* LoggingDetailsView.swift */,
 				01F34D0128A310A5003BDF17 /* Login.swift */,
 				01F34CEF28A30E88003BDF17 /* NetworkPage.swift */,
 				146ED3F929C4F2A000A56229 /* PeersListViewer.swift */,
@@ -239,8 +243,18 @@
 		0E8FA0692947FC5E00B2E38F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				142ED0E42A2687D3004D1BCB /* DittoLogging */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		142ED0E42A2687D3004D1BCB /* DittoLogging */ = {
+			isa = PBXGroup;
+			children = (
+				142ED0E52A2687D3004D1BCB /* LoggingDetailView.swift */,
+			);
+			name = DittoLogging;
+			path = ../Sources/DittoLogging;
 			sourceTree = "<group>";
 		};
 		F87DC4662988501000899FEC /* Packages */ = {
@@ -403,6 +417,7 @@
 				01F34CEC28A307CD003BDF17 /* ServerConnectionType.swift in Sources */,
 				01F34D0728A3119E003BDF17 /* MenuListItem.swift in Sources */,
 				01F34CEE28A307E2003BDF17 /* IdentityType.swift in Sources */,
+				142F962A2A268E48000C3664 /* LoggingDetailsView.swift in Sources */,
 				01F34CF028A30E88003BDF17 /* NetworkPage.swift in Sources */,
 				01F34CE928A307CD003BDF17 /* Transport.swift in Sources */,
 				01F34D0228A310A5003BDF17 /* Login.swift in Sources */,

--- a/DittoToolsApp/DittoToolsApp/Model/Config.swift
+++ b/DittoToolsApp/DittoToolsApp/Model/Config.swift
@@ -5,7 +5,9 @@
 //  Created by Rae McKelvey on 8/9/22.
 //
 
+import DittoSwift
 import Foundation
+
 
 struct DittoConfig {
     var appID = ""
@@ -16,3 +18,5 @@ struct DittoConfig {
     var authenticationToken = ""
     var useIsolatedDirectories = true
 }
+
+

--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -8,26 +8,14 @@ import Combine
 import DittoExportLogs
 import DittoExportData
 
+class MainListViewModel: ObservableObject {
+    @Published var isShowingLoginSheet = DittoManager.shared.ditto == nil
+}
+
 struct ContentView: View {
-    
-    class ViewModel: ObservableObject {
-
-        @Published var isShowingLoginSheet = DittoManager.shared.ditto == nil
-
-        var cancellables = Set<AnyCancellable>()
-        
-        var names: [String] = []
-        
-        func stopSync() {
-        }
-    }
     @Environment(\.colorScheme) private var colorScheme
-    @ObservedObject private var viewModel = ViewModel()
+    @StateObject private var viewModel = MainListViewModel()
     @ObservedObject private var dittoModel = DittoManager.shared
-
-    // Export Logs
-    @State private var presentExportLogsShare: Bool = false
-    @State private var presentExportLogsAlert: Bool = false
 
     // Export Ditto Directory
     @State private var presentExportDataShare: Bool = false
@@ -65,20 +53,9 @@ struct ContentView: View {
                         MenuListItem(title: "Change Identity", systemImage: "envelope", color: .purple)
                     }
                 }
-                Section(header: Text("Exports")) {
-                    // Export Logs
-                    Button(action: {
-                        self.presentExportLogsAlert.toggle()
-                    }) {
-                        HStack {
-                            MenuListItem(title: "Export Logs", systemImage: "square.and.arrow.up", color: .green)
-                            Spacer()
-                        }
-                    }
-                    .foregroundColor(textColor)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .sheet(isPresented: $presentExportLogsShare) {
-                        ExportLogs()
+                Section(header: Text("Exports")) { 
+                    NavigationLink(destination:  LoggingDetailsView()) {
+                        MenuListItem(title: "Logging", systemImage: "square.split.1x2", color: .green)
                     }
 
                     // Export Ditto Directory
@@ -99,17 +76,6 @@ struct ContentView: View {
             }
             .listStyle(InsetGroupedListStyle())
             .navigationTitle("Ditto Tools")
-            // Alerts
-            .alert("Export Logs", isPresented: $presentExportLogsAlert) {
-                Button("Export") {
-                    presentExportLogsShare = true
-                }
-                Button("Cancel", role: .cancel) {}
-
-            } message: {
-                Text("Compressing the logs may take a few seconds.")
-            }
-
             .alert("Export Ditto Directory", isPresented: $presentExportDataAlert) {
                 Button("Export") {
                     presentExportDataShare = true

--- a/DittoToolsApp/DittoToolsApp/Pages/LoggingDetailsView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/LoggingDetailsView.swift
@@ -1,0 +1,71 @@
+///
+//  LoggingDetailsView.swift
+//  DittoToolsApp
+//
+//  Created by Eric Turner on 5/30/23.
+//
+//  Copyright © 2023 DittoLive Incorporated. All rights reserved.
+
+import Combine
+import DittoExportLogs
+import SwiftUI
+
+struct LoggingDetailsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @ObservedObject var dittoManager = DittoManager.shared
+    @State private var presentExportLogsShare: Bool = false
+    @State private var presentExportLogsAlert: Bool = false
+
+    private var textColor: Color {
+        colorScheme == .dark ? .white : .black
+    }
+    
+    var body: some View {
+        List {
+            Section {
+                Text("Ditto Logging")
+                    .frame(width: 400, alignment: .center)
+                    .font(.title)
+            }
+            Section {
+                Picker("Logging Level", selection: $dittoManager.logLevel) {
+                    ForEach(AppSettings.LogLevel.allCases, id: \.self) { loggingOption in
+                        Text(loggingOption.description).tag(loggingOption)
+                    }
+                }
+            }
+            Section {
+                    // Export Logs
+                    Button(action: {
+                        self.presentExportLogsAlert.toggle()
+                    }) {
+                        HStack {
+                            MenuListItem(title: "Export Logs", systemImage: "square.and.arrow.up", color: .green)
+                            Spacer()
+                        }
+                    }
+                    .foregroundColor(textColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .sheet(isPresented: $presentExportLogsShare) {
+                    ExportLogs()
+                }
+            }
+        }
+        .listStyle(InsetGroupedListStyle())
+        .alert("Export Logs", isPresented: $presentExportLogsAlert) {
+            Button("Export") {
+                presentExportLogsShare = true
+            }
+            Button("Cancel", role: .cancel) {}
+
+        } message: {
+            Text("Compressing the logs may take a few seconds.")
+        }
+    }
+}
+
+struct LoggingDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoggingDetailsView()
+    }
+}

--- a/DittoToolsApp/DittoToolsApp/Pages/Login.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/Login.swift
@@ -10,6 +10,7 @@ struct Login: View {
         var error: String = ""
         @Published var useIsolatedDirectories = true
         @Published var config = DittoConfig()
+        @Published var logLevel: AppSettings.LogLevel = AppSettings.shared.logLevel
         
         init () {
             self.config = dittoModel.config
@@ -28,6 +29,10 @@ struct Login: View {
                 self.isPresentingAlert = true
                 self.error = err.localizedDescription
             }
+        }
+        
+        func setLoggingLevel() {
+            AppSettings.shared.logLevel = self.logLevel
         }
     }
     
@@ -71,8 +76,17 @@ struct Login: View {
                     }
                 }
                 Section {
+                    Picker("Logging Level", selection: $viewModel.logLevel) {
+                        ForEach(AppSettings.LogLevel.allCases, id: \.self) { loggingOption in
+                            Text(loggingOption.description).tag(loggingOption)
+                        }
+                    }
+                }
+                Section {
                     PrimaryFormButton(action: {
+                        viewModel.setLoggingLevel()
                         viewModel.changeIdentity()
+                        dismiss()
                     }, text: "Restart Ditto", textColor: viewModel.isDisabled ? .secondary : .accentColor, isLoading: false, isDisabled: false)
                 }
             }
@@ -87,10 +101,8 @@ struct Login: View {
             }) */
             .alert("Ditto failed to start.", isPresented: $viewModel.isPresentingAlert, actions: {
                     Button("Dismiss", role: .cancel) { dismiss() }
-                    
                 })
             }
-        
     }
 }
 

--- a/DittoToolsApp/DittoToolsApp/Pages/Login.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/Login.swift
@@ -10,7 +10,6 @@ struct Login: View {
         var error: String = ""
         @Published var useIsolatedDirectories = true
         @Published var config = DittoConfig()
-        @Published var logLevel: AppSettings.LogLevel = AppSettings.shared.logLevel
         
         init () {
             self.config = dittoModel.config
@@ -29,10 +28,6 @@ struct Login: View {
                 self.isPresentingAlert = true
                 self.error = err.localizedDescription
             }
-        }
-        
-        func setLoggingLevel() {
-            AppSettings.shared.logLevel = self.logLevel
         }
     }
     
@@ -76,15 +71,7 @@ struct Login: View {
                     }
                 }
                 Section {
-                    Picker("Logging Level", selection: $viewModel.logLevel) {
-                        ForEach(AppSettings.LogLevel.allCases, id: \.self) { loggingOption in
-                            Text(loggingOption.description).tag(loggingOption)
-                        }
-                    }
-                }
-                Section {
                     PrimaryFormButton(action: {
-                        viewModel.setLoggingLevel()
                         viewModel.changeIdentity()
                         dismiss()
                     }, text: "Restart Ditto", textColor: viewModel.isDisabled ? .secondary : .accentColor, isLoading: false, isDisabled: false)


### PR DESCRIPTION
This feature enables a user to set the Ditto logging level, or to disable logging.  The setting  
is stored in UserDefaults.standard, and when Ditto is restarted, logging begins from the last  
stored level; the default is .disabled. This feature introduces a LoggingDetailsView which hosts  
the new log level setting and the existing export logs feature.  

N.B. This commit builds on an initial logging level feature submitted as [PR 49](https://github.com/getditto/DittoSwiftTools/pull/49), implemented in the Login UI. This PR refactors  
to add the new `LoggingDetailsView` and to make log level changes effective immediately.  
    
- Ditto log level user setting and export logs in new dedicated UI  

