### PR TITLE
📌 DittoSwiftPackage (4.4.2-alpha1)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
             targets: ["DittoDiskUsage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.0.0"),
+        .package(url: "https://github.com/getditto/DittoSwiftPackage", Version(4, 4, 2, prereleaseIdentifiers: ["alpha1"])),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
This changes the dependency on DittoSwiftPackage to use a pre-release version. This doesn't need to be merged into the target branch, but would need to be tagged with `4.4.2-alpha1` in order to be consumable by an app or tool.