### PR TITLE
Release 4.4.2-alpha1

### DIFF
--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "63db2b032b5d3f6505ead0546e866a2caab401e2",
-        "version" : "4.0.0"
+        "revision" : "512817e11ad51aa8564fb8eb135ce43f680a83e9",
+        "version" : "4.4.2-alpha1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         // Ditto.diskUsage was added in 3.0.1
-        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.0.0"),
+        .package(url: "https://github.com/getditto/DittoSwiftPackage", exact: "4.4.2-alpha1"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
EXPERIMENTAL: this release is ONLY for use with DittoSwift 4.4.2-alpha1 pre-release SDK