### PR TITLE
Heartbeat feature

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/DittoDiskUsage.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DittoDiskUsage.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1520"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DittoExportData.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DittoExportData.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1520"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DittoExportLogs.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DittoExportLogs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1520"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DittoPeersList.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DittoPeersList.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1520"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DittoPresenceViewer.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DittoPresenceViewer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1520"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		01F34D0928A31644003BDF17 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F34D0828A31644003BDF17 /* AppDelegate.swift */; };
 		0E60040F2B7BFCD500C27FAF /* DittoPresenceDegradation in Frameworks */ = {isa = PBXBuildFile; productRef = 0E60040E2B7BFCD500C27FAF /* DittoPresenceDegradation */; };
 		0E6F0FA62B7C17270088C0CF /* PresenceDegradationViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6F0FA52B7C17270088C0CF /* PresenceDegradationViewer.swift */; };
+		0EFAEBC52B99322D00F26744 /* HeartBeatViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFAEBC42B99322D00F26744 /* HeartBeatViewer.swift */; };
 		146ED3F629C4F13100A56229 /* DittoPeersList in Frameworks */ = {isa = PBXBuildFile; productRef = 146ED3F529C4F13100A56229 /* DittoPeersList */; };
 		146ED3FA29C4F2A000A56229 /* PeersListViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146ED3F929C4F2A000A56229 /* PeersListViewer.swift */; };
 		1474FC932A295A3100C0AC4E /* LoggingDetailsViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474FC922A295A3100C0AC4E /* LoggingDetailsViewer.swift */; };
@@ -90,6 +91,7 @@
 		01F34D0628A3119E003BDF17 /* MenuListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListItem.swift; sourceTree = "<group>"; };
 		01F34D0828A31644003BDF17 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0E6F0FA52B7C17270088C0CF /* PresenceDegradationViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenceDegradationViewer.swift; sourceTree = "<group>"; };
+		0EFAEBC42B99322D00F26744 /* HeartBeatViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartBeatViewer.swift; sourceTree = "<group>"; };
 		146ED3F929C4F2A000A56229 /* PeersListViewer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeersListViewer.swift; sourceTree = "<group>"; };
 		1474FC922A295A3100C0AC4E /* LoggingDetailsViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingDetailsViewer.swift; sourceTree = "<group>"; };
 		F87DC46F298854E600899FEC /* DiskUsageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskUsageViewer.swift; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 		01F34D0028A310A5003BDF17 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
+				0EFAEBC42B99322D00F26744 /* HeartBeatViewer.swift */,
 				0E6F0FA52B7C17270088C0CF /* PresenceDegradationViewer.swift */,
 				016757D828A32E9400347491 /* CollectionView.swift */,
 				01F34C9628A2EAE3003BDF17 /* ContentView.swift */,
@@ -398,6 +401,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0EFAEBC52B99322D00F26744 /* HeartBeatViewer.swift in Sources */,
 				0E6F0FA62B7C17270088C0CF /* PresenceDegradationViewer.swift in Sources */,
 				01F34CD128A304F0003BDF17 /* AuthorizationsManager.swift in Sources */,
 				1474FC932A295A3100C0AC4E /* LoggingDetailsViewer.swift in Sources */,

--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		146ED3FA29C4F2A000A56229 /* PeersListViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146ED3F929C4F2A000A56229 /* PeersListViewer.swift */; };
 		1474FC932A295A3100C0AC4E /* LoggingDetailsViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474FC922A295A3100C0AC4E /* LoggingDetailsViewer.swift */; };
 		14B7342C2A296A4E0081CEF2 /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 14B7342B2A296A4E0081CEF2 /* DittoExportLogs */; };
+		14E35DB12B7F345C0018EC3B /* DittoHeartbeat in Frameworks */ = {isa = PBXBuildFile; productRef = 14E35DB02B7F345C0018EC3B /* DittoHeartbeat */; };
 		CC80DC002A1EACCE004A2A65 /* DittoExportData in Frameworks */ = {isa = PBXBuildFile; productRef = CC80DBFF2A1EACCE004A2A65 /* DittoExportData */; };
 		F87DC47C2988584200899FEC /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47B2988584200899FEC /* DittoDataBrowser */; };
 		F87DC4802988584200899FEC /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = F87DC47F2988584200899FEC /* DittoPresenceViewer */; };
@@ -106,6 +107,7 @@
 				0E60040F2B7BFCD500C27FAF /* DittoPresenceDegradation in Frameworks */,
 				F87DC47C2988584200899FEC /* DittoDataBrowser in Frameworks */,
 				14B7342C2A296A4E0081CEF2 /* DittoExportLogs in Frameworks */,
+				14E35DB12B7F345C0018EC3B /* DittoHeartbeat in Frameworks */,
 				146ED3F629C4F13100A56229 /* DittoPeersList in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -277,6 +279,7 @@
 				CC80DBFF2A1EACCE004A2A65 /* DittoExportData */,
 				14B7342B2A296A4E0081CEF2 /* DittoExportLogs */,
 				0E60040E2B7BFCD500C27FAF /* DittoPresenceDegradation */,
+				14E35DB02B7F345C0018EC3B /* DittoHeartbeat */,
 			);
 			productName = debug;
 			productReference = 01F34C9128A2EAE3003BDF17 /* DittoToolsApp.app */;
@@ -326,7 +329,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1340;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					01F34C9028A2EAE3003BDF17 = {
 						CreatedOnToolsVersion = 13.4.1;
@@ -351,7 +354,7 @@
 			);
 			mainGroup = 01F34C8828A2EAE3003BDF17;
 			packageReferences = (
-				0E523F442B59B1A0007D6665 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */,
+				14E35DB22B7F356A0018EC3B /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */,
 			);
 			productRefGroup = 01F34C9228A2EAE3003BDF17 /* Products */;
 			projectDirPath = "";
@@ -457,6 +460,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -489,6 +493,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -517,6 +522,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -549,6 +555,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -753,12 +760,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0E523F442B59B1A0007D6665 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
+		14E35DB22B7F356A0018EC3B /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
+			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 4.5.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -775,6 +782,10 @@
 		14B7342B2A296A4E0081CEF2 /* DittoExportLogs */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DittoExportLogs;
+		};
+		14E35DB02B7F345C0018EC3B /* DittoHeartbeat */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoHeartbeat;
 		};
 		CC80DBFF2A1EACCE004A2A65 /* DittoExportData */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/DittoToolsApp/DittoToolsApp.xcodeproj/xcshareddata/xcschemes/DittoToolsApp.xcscheme
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/xcshareddata/xcschemes/DittoToolsApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1520"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DittoToolsApp/DittoToolsApp/DittoManager.swift
+++ b/DittoToolsApp/DittoToolsApp/DittoManager.swift
@@ -7,9 +7,6 @@ import DittoExportLogs
 import DittoSwift
 import Foundation
 
-//TEST heartbeat
-import DittoHeartbeat
-
 class AuthDelegate: DittoAuthenticationDelegate {
     func authenticationRequired(authenticator: DittoAuthenticator) {
         let provider = DittoManager.shared.config.authenticationProvider
@@ -76,10 +73,6 @@ class DittoManager: ObservableObject {
 
     // MARK: - Private Constructor
 
-    //TMP: testing heartbeat
-    let TEST_HEARTBEAT = true
-    var heartbeatVM: HeartbeatVM? // = HeartbeatVM()
-    
     private init() {
         self.loggingOption = AppSettings.shared.loggingOption
         
@@ -90,31 +83,6 @@ class DittoManager: ObservableObject {
                 self?.setupLogging()
             }
             .store(in: &cancellables)
-      
-        if TEST_HEARTBEAT {
-            heartbeatVM = HeartbeatVM()
-            testingInit()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                self.testHeartbeat()
-            }
-        }
-    }
-    
-    //TMP: testing heartbeat
-    func testingInit() {
-        self.ditto = Ditto(
-            identity: .onlineWithAuthentication(
-                appID: self.config.appID, authenticationDelegate: self.authDelegate
-            ), persistenceDirectory: topLevelDittoDir()
-        )
-        do {
-            try ditto!.startSync()
-        } catch {
-            assertionFailure(error.localizedDescription)
-        }
-    }
-    func testHeartbeat() {
-        heartbeatVM?.test(ditto: self.ditto!)
     }
 
     func getPersistenceDir (config: DittoConfig) -> URL? {
@@ -179,8 +147,7 @@ class DittoManager: ObservableObject {
     }
 
     func setupLogging() {
-        //TEST Heartbeat
-        let logOption = DittoLogger.LoggingOptions.error //AppSettings.shared.loggingOption
+        let logOption = AppSettings.shared.loggingOption
         switch logOption {
         case .disabled:
             DittoLogger.enabled = false

--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -45,7 +45,7 @@ struct ContentView: View {
                     NavigationLink(destination: PresenceDegradationViewer()) {
                         MenuListItem(title: "Presence Degradation", systemImage: "network", color: .red)
                     }
-                    NavigationLink(destination: HeartbeatView(ditto: dittoModel.ditto!)) {
+                    NavigationLink(destination: HeartBeatViewer()) {
                         MenuListItem(title: "Heartbeat", systemImage: "heart.fill", color: .red)
                     }
                 }

--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -45,10 +45,7 @@ struct ContentView: View {
                     NavigationLink(destination: PresenceDegradationViewer()) {
                         MenuListItem(title: "Presence Degradation", systemImage: "network", color: .red)
                     }
-                    NavigationLink(
-                        destination:
-                            HeartbeatView(ditto: dittoModel.ditto!, config: DittoHeartbeatConfig.mock)
-                    ) {
+                    NavigationLink(destination: HeartbeatView(ditto: dittoModel.ditto!)) {
                         MenuListItem(title: "Heartbeat", systemImage: "heart.fill", color: .red)
                     }
                 }

--- a/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/ContentView.swift
@@ -4,6 +4,7 @@
 
 import Combine
 import DittoExportData
+import DittoHeartbeat
 import DittoSwift
 import SwiftUI
 
@@ -43,6 +44,12 @@ struct ContentView: View {
                     }
                     NavigationLink(destination: PresenceDegradationViewer()) {
                         MenuListItem(title: "Presence Degradation", systemImage: "network", color: .red)
+                    }
+                    NavigationLink(
+                        destination:
+                            HeartbeatView(ditto: dittoModel.ditto!, config: DittoHeartbeatConfig.mock)
+                    ) {
+                        MenuListItem(title: "Heartbeat", systemImage: "heart.fill", color: .red)
                     }
                 }
                 Section(header: Text("Configuration")) {

--- a/DittoToolsApp/DittoToolsApp/Pages/HeartBeatViewer.swift
+++ b/DittoToolsApp/DittoToolsApp/Pages/HeartBeatViewer.swift
@@ -1,0 +1,16 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Walker Erekson on 3/6/24.
+//
+
+import SwiftUI
+import DittoHeartbeat
+
+struct HeartBeatViewer: View {
+    var body: some View {
+        HeartbeatView(ditto: DittoManager.shared.ditto!)
+    }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -11,25 +11,36 @@ let package = Package(
     products: [
         .library(
             name: "DittoPresenceViewer",
-            targets: ["DittoPresenceViewer"]),
+            targets: ["DittoPresenceViewer"]
+        ),
         .library(
             name: "DittoDataBrowser",
-             targets: ["DittoDataBrowser"]),
+             targets: ["DittoDataBrowser"]
+        ),
         .library(
             name: "DittoExportLogs",
-            targets: ["DittoExportLogs"]),
+            targets: ["DittoExportLogs"]
+        ),
         .library(
             name: "DittoDiskUsage",
-            targets: ["DittoDiskUsage"]),
+            targets: ["DittoDiskUsage"]
+        ),
         .library(
             name: "DittoPeersList",
-            targets: ["DittoPeersList"]),
+            targets: ["DittoPeersList"]
+        ),
         .library(
             name: "DittoExportData",
-            targets: ["DittoExportData"]),
+            targets: ["DittoExportData"]
+        ),
         .library(
             name: "DittoPresenceDegradation",
-            targets: ["DittoPresenceDegradation"]),
+            targets: ["DittoPresenceDegradation"]
+        ),
+        .library(
+            name: "DittoHeartbeat",
+            targets: ["DittoHeartbeat"]
+        ),
     ],
     dependencies: [
         // Ditto.diskUsage was added in 3.0.1
@@ -51,8 +62,7 @@ let package = Package(
             cxxSettings: [
                 .define("ENABLE_BITCODE", to: "NO")
             ]
-        ),
-        
+        ),        
         .target(
             name: "DittoDataBrowser",
             dependencies: [
@@ -61,7 +71,6 @@ let package = Package(
             ],
             path: "Sources/DittoDataBrowser"
         ),
-
         .target(
             name: "DittoExportLogs",
             dependencies: [
@@ -69,7 +78,6 @@ let package = Package(
             ],
             path: "Sources/DittoExportLogs"
         ),
-
         .target(
             name: "DittoDiskUsage",
             dependencies: [
@@ -77,7 +85,6 @@ let package = Package(
             ],
             path: "Sources/DittoDiskUsage"
         ),
-        
         .target(
             name: "DittoPeersList",
             dependencies: [
@@ -98,6 +105,13 @@ let package = Package(
                 .product(name: "DittoSwift", package: "DittoSwiftPackage")
             ],
             path: "Sources/DittoPresenceDegradation"
+        ),
+        .target(
+            name: "DittoHeartbeat",
+            dependencies: [
+                .product(name: "DittoSwift", package: "DittoSwiftPackage")
+            ],
+            path: "Sources/DittoHeartbeat"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -396,13 +396,106 @@ struct PresenceDegradationViewer: View {
 
 **UIKit**  
 
-Pass `PresenceDegradationView(ditto: <diito>)` to a [UIHostingController](https://sarunw.com/posts/swiftui-in-uikit/) 
+Pass `PresenceDegradationView(ditto: <ditto>)` to a [UIHostingController](https://sarunw.com/posts/swiftui-in-uikit/) 
 which will return a view controller you can use to present.  
 
 ```
 let vc = UIHostingController(rootView: PresenceDegradationView(ditto: <diito>))
 
 present(vc, animated: true)
+```
+
+### 9. Heartbeat
+
+The Ditto Heartbeat tool allows you to monitor, locally or remotely, the peers in your mesh.
+
+**Configure Heartbeat**
+
+There are three values you need to provide to the Heartbeat:
+1. Id/Id's - Provide all the Id's needed in order to identify a peer
+2. Interval - The frequency at which the Heartbeat will scrape the data
+3. Collection Name - The Ditto collection you want to add this data to
+4. Meta Data -  This field is optional
+
+There is a `DittoHeartbeatConfig` struct you can use to construct your configuration.
+
+```swift
+// Provided with the Heartbeat tool
+public struct DittoHeartbeatConfig {
+    public var id: [String: String]
+    public var secondsInterval: Int
+    public var collectionName: String
+    public var metadata: [String: Any]?
+    
+    public init(id: [String : String], secondsInterval: Int, collectionName: String, metadata: [String : Any]? = nil) {
+        self.id = id
+        self.secondsInterval = secondsInterval
+        self.collectionName = collectionName
+        self.metadata = metadata
+    }
+}
+```
+
+This tool generates a `DittoHeartbeatInfo` object with the given data:
+```swift
+public struct DittoHeartbeatInfo: Identifiable {
+    public var id: [String: String]
+    public var secondsInterval: Int
+    public var lastUpdated: String
+    public var sdk: String
+    public var remotePeersCount: Int { peerConnections.count }
+    public var peerConnections: [DittoPeerConnection]
+    public var metadata: [String: Any]
+}
+
+public struct DittoPeerConnection {
+    public var deviceName: String
+    public var sdk: String
+    public var isConnectedToDittoCloud: Bool
+    public var bluetooth: Int
+    public var p2pWifi: Int
+    public var lan: Int
+    public var peerKey: String
+}
+```
+
+You can either use the provided UI from this tool or you can read the `DittoHeartbeatInfo` data and create your own UI/use the data as you please.
+
+**Use provided UI:**
+
+**SwiftUI**  
+
+Use `HeartbeatView(ditto: dittoModel.ditto!, config: heartbeatConfig)`, passing in your Ditto instance and your DittoHeartbeatConfig object.  
+
+```
+import DittoHeartbeat
+
+struct HeartbeatViewer: View {
+    var body: some View {
+        HeartbeatView(ditto: <ditto>, config: <heartbeatConfig>)
+    }
+}
+```
+
+**UIKit**  
+
+Pass `HeartbeatView(ditto: <ditto>, config: <heartbeatConfig>)` to a [UIHostingController](https://sarunw.com/posts/swiftui-in-uikit/) 
+which will return a view controller you can use to present.  
+
+```
+let vc = UIHostingController(rootView: HeartbeatView(ditto: <ditto>, config: <heartbeatConfig>))
+
+present(vc, animated: true)
+```
+
+**Read data only:**
+
+Create a `HeartbeatVM(ditto: <ditto>` object and then call `startHeartbeat(config: DittoHeartbeatConfig, callback: @escaping HeartbeatCallback)`. You can access the data in the callback of `startHeartbeat`
+```swift
+var heartBeatVm = HeartbeatVM(ditto: DittoManager.shared.ditto!)
+heartBeatVm.startHeartbeat(config: DittoHeartbeatConfig(id: [String:String], secondsInterval: Int, collectionName: String, metadata: metadata: [String:Any]? )) { heartbeatInfo in
+        //use data
+} 
 ```
 
 ## Ditto Tools Example App

--- a/Sources/DittoHeartbeat/HeartbeatModels.swift
+++ b/Sources/DittoHeartbeat/HeartbeatModels.swift
@@ -14,6 +14,13 @@ public struct DittoHeartbeatConfig {
     public var secondsInterval: Int
     public var collectionName: String
     public var metadata: [String: Any]?
+    
+    public init(id: [String : String], secondsInterval: Int, collectionName: String, metadata: [String : Any]? = nil) {
+        self.id = id
+        self.secondsInterval = secondsInterval
+        self.collectionName = collectionName
+        self.metadata = metadata
+    }
 }
 
 //MARK: HeartbeatInfo

--- a/Sources/DittoHeartbeat/HeartbeatModels.swift
+++ b/Sources/DittoHeartbeat/HeartbeatModels.swift
@@ -1,0 +1,128 @@
+///
+//  HeartbeatModels.swift
+//  
+//
+//  Created by Eric Turner on 2/22/24.
+//
+//  Copyright © 2024 DittoLive Incorporated. All rights reserved.
+
+import Foundation
+
+//MARK: HeartbeatConfig
+public struct DittoHeartbeatConfig {
+    public var id: [String: String]
+    public var secondsInterval: Int
+    public var collectionName: String
+    public var metadata: [String: Any]?
+}
+
+//MARK: HeartbeatInfo
+public struct DittoHeartbeatInfo: Identifiable {
+    public var id: [String: String]
+    public var secondsInterval: Int
+    public var lastUpdated: String
+    public var sdk: String
+    public var remotePeersCount: Int { peerConnections.count }
+    public var peerConnections: [DittoPeerConnection]
+    public var metadata: [String: Any]
+    
+    public init(
+        id: [String: String],
+        secondsInterval: Int = Int.max,
+        lastUpdated: String = DateFormatter.isoDate.string(from: Date()),
+        sdk: String = "",
+        peersCount: Int = 0,
+        peerConnections: [DittoPeerConnection] = [],
+        metadata: [String: Any] = [:]
+    ) {
+        self.id = id
+        self.secondsInterval = secondsInterval
+        self.lastUpdated = lastUpdated
+        self.sdk = sdk
+        self.peerConnections = peerConnections
+        self.metadata = metadata
+    }
+}
+
+public extension DittoHeartbeatInfo {
+    init(_ resultItem: [String:Any?]) {
+        id = resultItem[String._id] as? [String:String] ?? [:]
+        secondsInterval = resultItem[String.secondsInterval] as? Int ?? 0
+        lastUpdated = resultItem[String.lastUpdated] as? String ?? String.NA
+        sdk = resultItem[String.sdk] as? String ?? String.NA
+        peerConnections = Self.connections(resultItem[String.peerConnections] as? [String:Any] ?? [:])
+        metadata = resultItem[String.metadata] as? [String:Any] ?? [:]
+    }
+    
+    fileprivate static func connections(_ cxs: [String:Any]) -> [DittoPeerConnection] {
+        cxs.map { (key, val) in DittoPeerConnection(key, cx: val as! [String:Any]) }
+    }
+    
+    var value: [String:Any] {
+        [
+            String._id: id,
+            String.secondsInterval: secondsInterval,
+            String.lastUpdated: lastUpdated,
+            String.sdk: sdk,
+            String.remotePeersCount: peerConnections.count,
+            String.peerConnections: connectionsValue(),
+            String.metadata: metadata
+        ]
+    }
+    
+    fileprivate func connectionsValue() -> [String:Any] {
+        var cxVal = [String:Any]()
+        for cx in peerConnections {
+            cxVal[cx.peerKey] = cx.value
+        }
+        return cxVal
+    }
+}
+
+//MARK: PeerConnection
+public struct DittoPeerConnection {
+    public var deviceName: String
+    public var sdk: String
+    public var isConnectedToDittoCloud: Bool
+    public var bluetooth: Int
+    public var p2pWifi: Int
+    public var lan: Int
+    public var peerKey: String
+}
+
+extension DittoPeerConnection {
+    public init(_ key: String, cx: [String:Any]) {
+        deviceName = cx[String.deviceName] as? String ?? String.deviceNameNA
+        sdk = cx[String.sdk] as? String ?? String.sdkNA
+        isConnectedToDittoCloud = cx[String.isConnectedToDittoCloud] as? Bool ?? false
+        bluetooth = cx[String.bluetooth] as? Int ?? 0
+        p2pWifi = cx[String.p2pWifi] as? Int ?? 0
+        lan = cx[String.lan] as? Int ?? 0
+        peerKey = key
+    }
+    
+    public var value: [String:Any] {
+        [
+            String.deviceName: deviceName,
+            String.sdk: sdk,
+            String.isConnectedToDittoCloud: isConnectedToDittoCloud,
+            String.bluetooth: bluetooth,
+            String.p2pWifi: p2pWifi,
+            String.lan: lan
+            /* peerKey: not included in doc values */
+        ]
+    }
+}
+
+
+//MARK: HeartbeatConfig Mock
+public extension DittoHeartbeatConfig {
+    static var mock: DittoHeartbeatConfig {
+        DittoHeartbeatConfig(
+            id: ["location": "Kalamazoo", "venue": "FoodTruck_01"],
+            secondsInterval: 10,
+            collectionName: "devices",
+            metadata: ["metadata-key1": "metadata-value1", "metadata-key2": "metadata-value2"]
+        )
+    }
+}

--- a/Sources/DittoHeartbeat/HeartbeatStrings.swift
+++ b/Sources/DittoHeartbeat/HeartbeatStrings.swift
@@ -1,0 +1,37 @@
+///
+//  HeartbeatStrings.swift
+//
+//
+//  Created by Eric Turner on 2/22/24.
+//
+//  Copyright © 2024 DittoLive Incorporated. All rights reserved.
+
+import Foundation
+
+public extension String {
+    static var bt = "bt"
+    static var bluetooth = "bluetooth"
+    static var deviceName = "deviceName"
+    static var deviceNameNA = "deviceName N/A"
+    static var hbInfoTitle = "Heartbeat Info"
+    static var _id = "_id"
+    static var id = "id"
+    static var imgPause = "pause.circle"
+    static var imgPlay = "play.circle"
+    static var isConnectedToDittoCloud = "isConnectedToDittoCloud"
+    static var lan = "lan"
+    static var lastUpdated = "lastUpdated"
+    static var lastUpdatedText = "last updated"
+    static var metadata = "metadata"
+    static var NA = "N/A"
+    static var osNA = "OS: N/A"
+    static var p2pWifi = "p2pWifi"
+    static var peerConnections = "peerConnections"
+    static var pk = "pk"
+    static var remotePeersCount = "remotePeersCount"
+    static var remotePeers = "remote peers"
+    static var secondsInterval = "secondsInterval"
+    static var sdk = "sdk"
+    static var sdkNA = "sdk N/A"
+    static var sdkVersionNA = ": N/A"
+}

--- a/Sources/DittoHeartbeat/HeartbeatStrings.swift
+++ b/Sources/DittoHeartbeat/HeartbeatStrings.swift
@@ -36,9 +36,11 @@ public extension String {
     static var sdkVersionNA = ": N/A"
     
     static var getStartedText = "To demo the Heartbeat feature, just hit the play button. "
-    + "Mock HeartbeatConfig data will be used to begin updating a local device heartbeat document "
-    + " in the `devices` collection every 10 seconds.\n\n"
-    + "If you are using the standalone DittoToolsApp, you must first reset the identity to activate "
+    + "A hearbeat document for this device will be added to the `devices` collection, and mock "
+    + "HeartbeatConfig data will be used to update the document every 10 seconds. "
+    + "Hearbeat documents for this and other devices with the heartbeat feature enabled "
+    + "will appear in a list here.\n\n"
+    + "If using the standalone DittoToolsApp, you must first reset the identity to activate "
     + "Ditto. Note that every time the Ditto identity is reset in this way, the Ditto instance will "
-    + "be seen as a new local peer and will create a new HeartbeatInfo document."
+    + "be seen as a new local peer and will create a new HeartbeatInfo document with a new unique ID."
 }

--- a/Sources/DittoHeartbeat/HeartbeatStrings.swift
+++ b/Sources/DittoHeartbeat/HeartbeatStrings.swift
@@ -34,4 +34,11 @@ public extension String {
     static var sdk = "sdk"
     static var sdkNA = "sdk N/A"
     static var sdkVersionNA = ": N/A"
+    
+    static var getStartedText = "To demo the Heartbeat feature, just hit the play button. "
+    + "Mock HeartbeatConfig data will be used to begin updating a local device heartbeat document "
+    + " in the `devices` collection every 10 seconds.\n\n"
+    + "If you are using the standalone DittoToolsApp, you must first reset the identity to activate "
+    + "Ditto. Note that every time the Ditto identity is reset in this way, the Ditto instance will "
+    + "be seen as a new local peer and will create a new HeartbeatInfo document."
 }

--- a/Sources/DittoHeartbeat/HeartbeatVM.swift
+++ b/Sources/DittoHeartbeat/HeartbeatVM.swift
@@ -37,8 +37,7 @@ public class HeartbeatVM: ObservableObject {
         self.ditto = ditto
     }
     
-    public func startHeartbeat(ditto: Ditto, config: DittoHeartbeatConfig, callback: @escaping HeartbeatCallback) {
-        self.ditto = ditto
+    public func startHeartbeat(config: DittoHeartbeatConfig, callback: @escaping HeartbeatCallback) {
         isEnabled = true
         hbConfig = config
         hbCallback = callback

--- a/Sources/DittoHeartbeat/HeartbeatVM.swift
+++ b/Sources/DittoHeartbeat/HeartbeatVM.swift
@@ -1,0 +1,332 @@
+///
+//  HeartbeatVM.swift
+//  DittoChat
+//
+//  Created by Eric Turner on 02/01/24.
+//
+//  Copyright © 2024 DittoLive Incorporated. All rights reserved.
+
+import Combine
+import CryptoKit
+import DittoSwift
+import SwiftUI
+
+public extension DateFormatter {
+    static var isoDate: ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        return f
+    }
+}
+
+public struct HeartbeatConfig {
+    var id: [String: String]
+    var interval: TimeInterval
+    var collectionName: String
+}
+
+public struct HeartbeatInfo {
+    var id: [String: String]
+    var lastUpdated: String
+    var presence: Presence?
+}
+
+public struct Presence {
+    var peers: [DittoPeer]
+    var remotePeersCount: Int
+    init(peers: [DittoPeer], remoteCount: Int) {
+        self.peers = peers
+        self.remotePeersCount = remoteCount
+    }
+}
+
+public typealias HeartbeatCallback = (HeartbeatInfo) -> Void
+
+@available(iOS 15, *)
+public class HeartbeatVM: ObservableObject {
+    @Published var isEnabled = false
+    private var hbConfig: HeartbeatConfig?
+    private var hbInfo: HeartbeatInfo?
+    private var hbCallback: HeartbeatCallback?
+    private var hbSubscription: DittoSyncSubscription?
+    private var insertQuery: String?
+    private var ditto: Ditto?
+    private var presence: Presence?
+    private var peersObserver: DittoSwift.DittoObserver?
+    private var timer: Timer.TimerPublisher?
+    private var cancellable = AnyCancellable({})
+    private var infoCurrentValueSubject = CurrentValueSubject<HeartbeatInfo?, Never>(nil)
+    private var subjectCancellable = AnyCancellable({})
+    public var infoPublisher: AnyPublisher<HeartbeatInfo?, Never> {
+        infoCurrentValueSubject.eraseToAnyPublisher()
+    }
+    
+    //TEST
+    var testObserver: DittoStoreObserver?
+
+    
+    public init(ditto: Ditto? = nil) {
+        self.ditto = ditto
+    }
+    
+    public func startHeartbeat(ditto: Ditto, config: HeartbeatConfig, callback: @escaping HeartbeatCallback) {
+        self.ditto = ditto
+        isEnabled = true
+        hbConfig = config
+        hbCallback = callback
+        hbInfo = HeartbeatInfo(
+            id: createCompositeId(config: config.id),
+            lastUpdated: DateFormatter.isoDate.string(from: Date.now),
+            presence: nil
+        )
+        observePeers()
+        startTimer()
+        
+        hbSubscription = try? ditto.sync.registerSubscription(query: "SELECT * FROM \(config.collectionName)")
+        insertQuery = "INSERT INTO \(config.collectionName) DOCUMENTS (:doc) ON ID CONFLICT DO UPDATE"
+    }
+    
+    public func stopHeartbeat() {
+        stopTimer()
+        isEnabled = false
+        peersObserver?.stop()
+        hbSubscription?.cancel()
+    }
+    
+    private func startTimer() {
+        guard let config = hbConfig else {
+            print("HeartbeatVM.\(#function): config is NIL --> Return")
+            return
+        }
+        
+        timer?.connect().cancel()
+        timer = Timer.publish(every: config.interval, on: .main, in: .common)
+        
+        cancellable = timer!
+            .autoconnect()
+            .receive(on: DispatchQueue.main)
+            .sink {[weak self] date in
+                guard let self = self else { return }
+                hbInfo?.lastUpdated = DateFormatter.isoDate.string(from: Date.now)
+                updateCollection()
+                emit()
+            }
+    }
+    
+    private func stopTimer() {
+        timer?.connect().cancel()
+        timer = nil
+    }
+    
+    private func observePeers() {
+        guard isEnabled else { return }
+        
+        peersObserver = ditto?.presence.observe {[weak self] graph in
+            DispatchQueue.main.async {[weak self] in
+                guard let self = self else { return }
+                let peers = graph.remotePeers
+                presence = Presence(peers: peers, remoteCount: peers.count)
+                hbInfo?.presence = presence
+            }
+        }
+    }
+    
+    private func emit() {
+        infoCurrentValueSubject.send(hbInfo)
+        
+        if let callback = hbCallback, let info = hbInfo {
+            callback(info)
+        }
+    }
+    
+    private func updateCollection() {
+        guard let config = hbConfig, let info = hbInfo, let presence = info.presence else {
+            print("HeartbeatVM.\(#function): hbConfig and/or bhInfo and/or hbInfo.presence is NIL --> Return")
+            return
+        }
+        
+        let doc: [String:Any?] = [
+            "_id": info.id,
+            "interval": "\(Int(config.interval)) sec",
+            "remotePeersCount": presence.remotePeersCount,
+            "lastUpdated": info.lastUpdated,
+            "presence": getConnections()
+        ]
+        Task {
+            do {
+                if let query = insertQuery {
+                    try await ditto?.store.execute(query: query, arguments: ["doc": doc])
+                } else {
+                    print("HeartbeatVM.\(#function): ERROR: insertQuery should not be NIL")
+                }
+            } catch {
+                print(
+                    "HeartbeatVM.\(#function) - ERROR updating collection: " +
+                    "\(hbConfig?.collectionName ?? "collection name N/A")\n" +
+                    "error: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+    
+    private func getConnections() -> [String: Any?] {
+        guard let info = hbInfo, let presence = info.presence else {
+            print("HeartbeatVM.\(#function): bhInfo and/or hbInfo.presence is NIL --> Return")
+            return [:]
+        }
+        
+        var connections = [String: Any]()
+        
+        for peer in presence.peers {
+            let types = connectionTypeCounts(peer: peer)
+            let connection: [String: Any?] =
+            [
+                "deviceName": peer.deviceName,
+                "isConnectedToDittoCloud": peer.isConnectedToDittoCloud,
+                "bluetooth": types["bt"],
+                "p2pWifi": types["p2pWifi"],
+                "lan": types["lan"]
+            ]
+            
+            connections["dittoPeerKey"] = connection
+        }
+        
+        return connections
+    }
+    
+    private func connectionTypeCounts(peer: DittoPeer) -> [String: Int] {
+        var bt = 0
+        var wifi = 0
+        var lan = 0
+        
+        for cx in peer.connections {
+            switch cx.type {
+            case .bluetooth: bt += 1
+            case .p2pWiFi: wifi += 1
+            case .accessPoint, .webSocket: lan += 1
+            @unknown default:
+                break
+            }
+        }
+        return ["bt": bt, "p2pWifi": wifi, "lan": lan]
+    }
+    
+    private func createCompositeId(config: [String: String]) -> [String: String] {
+        var compositeId = config
+        compositeId["dittoPeerKey"] = peerKeyHash(ditto?.presence.graph.localPeer.peerKey ?? Data())
+        return compositeId
+    }
+    
+    private func peerKeyHash(_ data: Data) -> String {
+        let hash = Insecure.MD5.hash(data: data)
+        return hash.map { String(format: "%02hhx", $0) }.joined()
+    }
+    
+    //TMP: for HeartbeatView
+    public var peers: [DittoPeer] {
+        hbInfo?.presence?.peers ?? []
+    }
+    
+    /* from orig */
+    func isLocalPeer(_ peer: DittoPeer) -> Bool {
+        //        peer.peerKey == localPeer.peerKey
+        guard let presence = ditto?.presence else { return false }
+        return peer.peerKey == presence.graph.localPeer.peerKey
+    }
+    
+    func connectionsWithLocalPeer(_ peer: DittoPeer) -> [DittoConnection] {
+        //        peer.connections.filter { $0.peer1 == localPeer.peerKey || $0.peer2 == localPeer.peerKey }
+        guard let presence = ditto?.presence else { return [] }
+        let localPeer = presence.graph.localPeer
+        return peer.connections.filter { $0.peer1 == localPeer.peerKey || $0.peer2 == localPeer.peerKey }
+    }
+    
+    func formattedDistanceString(_ dbl: Double?) -> String {
+        Double.metricString(dbl ?? 0, digits: 2)
+    }
+    
+    func cleanup() {
+        peersObserver?.stop()
+    }
+}
+
+@available(iOS 15, *)
+extension HeartbeatVM {
+    public func test(ditto: Ditto) {
+        startHeartbeat(ditto: ditto, config: HeartbeatConfig.mock) { [weak self] info in
+            guard let self = self else { return }
+            if testObserver == nil {
+               startTestObserver()
+            }
+            print("HeartbeatVM.\(#function): info.presence.peersCount: \(info.presence?.remotePeersCount ?? -1)")
+        }
+    }
+    func startTestObserver() {
+        testObserver = try? ditto!.store.registerObserver(
+            query: hbSubscription!.queryString,
+            arguments: hbSubscription!.queryArguments
+        ) { result in
+            let _ = result.items.compactMap { print("Heartbeat query item: \($0.value)") }
+        }
+    }
+}
+
+extension DittoPeer {
+    var peerSDKVersion: String {
+        let sdk = "SDK "
+        if let version = dittoSDKVersion {
+            return sdk + "v\(version)"
+        }
+        return sdk + "N/A"
+    }
+        
+    var addressSiteId: String {
+        Self.addressSiteId(self)
+    }
+    
+    static func addressSiteId(_ peer: DittoPeer) -> String {
+        // parse siteID out of DittoAddress description
+        let prefix = "\(peer.address)".components(separatedBy: "DittoAddress(siteID: ")
+        let addr = String(prefix.last ?? "").components(separatedBy: ",")
+        return String(addr.first ?? "[siteID N/A]")
+    }
+}
+
+// For sorting addresses of remote peers in func remotePeerAddresses() above
+extension DittoAddress: Comparable {
+    public static func < (lhs: DittoSwift.DittoAddress, rhs: DittoSwift.DittoAddress) -> Bool {
+        lhs.hashValue < rhs.hashValue
+    }
+}
+
+extension Double {
+    private static var decimalFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }
+
+    static func metricString(_ dbl: Double, digits: Int) -> String {
+        let formatter = Self.decimalFormatter
+        formatter.maximumFractionDigits = digits
+        return formatter.string(from: dbl as NSNumber) ?? "N/A"
+    }
+}
+
+@available(iOS 15, *)
+//public extension HeartbeatVM {
+////    func test(ditto: Ditto, config: HeartbeatConfig, callback: HeartbeatCallback) {
+//    func test(ditto: Ditto) {
+//        startHeartbeat(ditto: ditto, config: HeartbeatConfig.mock) { info in
+//            print("HeartbeatVM.\(#function): info:\n\(info)")
+//        }
+//    }
+//}
+extension HeartbeatConfig {
+    static var mock: HeartbeatConfig {
+        HeartbeatConfig(
+            id: ["location": "loc_abc123", "venue": "ven_def456"],
+            interval: 10,
+            collectionName: "devices"
+        )
+    }
+}

--- a/Sources/DittoHeartbeat/HeartbeatView+Extensions.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView+Extensions.swift
@@ -1,0 +1,103 @@
+///
+//  HeartbeatView+Extensions.swift
+//  
+//
+//  Created by Eric Turner on 2/22/24.
+//
+//  Copyright © 2024 DittoLive Incorporated. All rights reserved.
+
+import DittoSwift
+import SwiftUI
+
+//MARK: View Extensions
+@available(iOS 15, *)
+
+public struct HeartbeatInfoView: View {
+    let info: DittoHeartbeatInfo
+    init(_ nfo: DittoHeartbeatInfo) { info = nfo }
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            Text("\(String.id): \(info.idString)")
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("\(String.secondsInterval): \(info.secondsInterval) sec")
+            Text("\(String.lastUpdatedText): \(info.lastUpdated)")
+            Text("\(String.metadata): \(info.metadataString)")
+            Text("\(String.remotePeersCount): \(info.peerConnections.isEmpty ? 0 : info.remotePeersCount)")
+            if info.remotePeersCount > 0 {
+                Text("\(String.remotePeers):\n\(info.peersString)")
+            }
+        }
+    }
+}
+
+@available(iOS 15, *)
+public struct HeartbeatInfoRowItem: View {
+    let info: DittoHeartbeatInfo
+    public var body: some View {
+        HeartbeatInfoView(info)
+    }
+}
+
+
+
+//MARK: Heartbeat Model View Extension
+@available(iOS 15, *)
+
+public extension DittoHeartbeatInfo {
+    
+    var idString: String {
+        let indent = "     "
+        let meta = id[String.pk]
+        var retStr = ""
+        
+        for key in Array(id.keys).sorted() {
+            if key == String.pk { continue }
+            retStr += "\(key): \(id[key]!)\n\(indent)"
+        }
+        if let meta = meta { retStr += (.pk + ": \(meta)") }
+        
+        return retStr
+    }
+    
+    var metadataString: String {
+        var retStr = ""
+        let indent = "     "
+        for key in Array(metadata.keys).sorted() {
+            let val = metadata[key]
+            let valStr = val as? String ?? String(describing: val)
+            retStr += "\n\(indent)\(key): \(valStr)"
+        }
+        
+        return retStr
+    }
+    
+    var peersString: String {
+        var str = ""
+        for cx in peerConnections.sorted(by: { $0.peerKey < $1.peerKey }) {
+            str += "\(cx)\n"
+        }
+        return str
+    }
+}
+
+
+//MARK: Heartbeat Model PeerConnection Extension
+@available(iOS 15, *)
+
+extension DittoPeerConnection: CustomStringConvertible {
+
+    public var description: String {
+        """
+             \(String.deviceName): \(deviceName)
+             \(String.sdk): \(sdk)
+             \(String.isConnectedToDittoCloud): \(isConnectedToDittoCloud)
+             \(String.bluetooth): \(bluetooth)
+             \(String.p2pWifi): \(p2pWifi)
+             \(String.lan): \(lan)
+             \(String.pk): \(peerKey)
+        """
+    }
+}
+

--- a/Sources/DittoHeartbeat/HeartbeatView.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView.swift
@@ -1,0 +1,119 @@
+///
+//  HeartbeatView.swift
+//  DittoSwiftTools
+//
+//  Created by Eric Turner on 02/01/24.
+//
+//  Copyright © 2024 DittoLive Incorporated. All rights reserved.
+
+import DittoSwift
+import SwiftUI
+
+@available(iOS 15, *)
+public struct HeartbeatView: View {
+    @StateObject var vm = HeartbeatVM()
+    private let dividerColor: Color
+    
+//    static var footerText: String {
+//        "BLE approximate distance is inaccurate."
+//    }
+        
+    public init(ditto: Ditto) {
+//        self._vm = StateObject(wrappedValue: HeartbeatVM(ditto: ditto))
+        self.dividerColor = .accentColor
+    }
+    
+    public var body: some View {
+        EmptyView()
+        /*
+        List {
+            Section {
+                peerView(vm.localPeer, showBLEDistance: true)
+            } header: {
+                Text("Local (Self) Peer")
+                    .font(Font.subheadline.weight(.bold))
+            } footer: {
+                Text(Self.footerText)
+            }
+            .listRowSeparator(.visible, edges: .top)
+            .listRowSeparatorTint(dividerColor)
+            
+            Section {
+                ForEach(vm.peers, id: \.address) { peer in
+                    peerView(peer)
+                        .padding(.bottom, 4)
+                        .listRowSeparator(.visible, edges: .top)
+                        .listRowSeparatorTint(dividerColor)
+                }
+            } header: {
+                Text("Remote Peers")
+                    .font(Font.subheadline.weight(.bold))
+            } footer: {
+                Text(Self.footerText)
+            }
+        }
+        .onDisappear { vm.cleanup() }
+        .navigationTitle("Peers List")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    vm.isPaused.toggle()
+                } label: {
+                    Image(systemName: vm.isPaused ? "play.circle" : "pause.circle")
+                        .symbolRenderingMode(.multicolor)
+                }
+                .font(.system(size: 24))
+                .foregroundColor(.accentColor)
+                .buttonStyle(.borderless)
+            }
+        }
+         */
+    }
+    
+    @ViewBuilder
+    func peerView(_ peer: DittoPeer, showBLEDistance: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            
+            // Device name + siteID
+            Text("\(peer.deviceName): ").font(Font.body.weight(.bold))
+            + Text("\(peer.addressSiteId)").font(Font.subheadline.weight(.bold))
+            
+            if vm.isLocalPeer(peer) {
+                ForEach(vm.peers, id: \.self) { conPeer in
+                    VStack(alignment: .leading) {
+                        Divider()
+                            .frame(height: 1)
+                            .overlay(.gray).opacity(0.4)
+                        
+                        Text("peer: \(DittoPeer.addressSiteId(conPeer))")
+                        
+                        peerConnectionsView(conPeer, showBLEDistance: showBLEDistance)
+                    }
+                    .padding(.leading, 16)
+                }
+            }
+            Text(peer.peerSDKVersion).font(.subheadline)
+        }
+    }
+    
+    @ViewBuilder
+    func peerConnectionsView(_ peer: DittoPeer, showBLEDistance: Bool = false) -> some View {
+        VStack(alignment: .leading) {
+            ForEach(vm.connectionsWithLocalPeer(peer)) { conx in
+                HStack {
+                    Text("-\(conx.type.rawValue)")
+                        .padding(.leading, 16)
+
+                    Spacer()
+
+                    if showBLEDistance && conx.type == DittoConnectionType.bluetooth {
+                        Text("\(vm.formattedDistanceString(conx.approximateDistanceInMeters))m")
+                    } else {
+                        Text("-")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/DittoHeartbeat/HeartbeatView.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView.swift
@@ -45,7 +45,7 @@ private class PrivateHeartbeatVM: ObservableObject {
         // Use mock config for demo if nil
         let hbConfig = config ?? DittoHeartbeatConfig.mock
         
-        hbVM.startHeartbeat(ditto: ditto, config: hbConfig) { [weak self] info in
+        hbVM.startHeartbeat(config: hbConfig) { [weak self] info in
             guard let self = self else { return }
             if infoObserver == nil {
                startInfoObserver()

--- a/Sources/DittoHeartbeat/HeartbeatView.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView.swift
@@ -61,7 +61,9 @@ private class PrivateHeartbeatVM: ObservableObject {
             let docs = result.items.compactMap { item in
                 DittoHeartbeatInfo(item.value)
             }
-            infoDocs = docs
+            withAnimation {
+                self.infoDocs = docs
+            }
         }
     }
 }
@@ -79,10 +81,30 @@ public struct HeartbeatView: View {
     
     public var body: some View {
         VStack {
-            List {
-                ForEach(vm.infoDocs) { info in
-                    HeartbeatInfoRowItem(info: info)
+            if vm.isPaused && vm.infoDocs.count < 1 {
+                VStack(alignment: .center) {
+                    Text(String.getStartedText)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 28)
+                    
+                    Button(action: {
+                        vm.isPaused.toggle()
+                    }, label: {
+                        Image(systemName: String.imgPlay)
+                            .symbolRenderingMode(.multicolor)
+                            .font(.system(size: 60))
+                    })
+                    
+                    Spacer()
                 }
+            } else {
+                List {
+                    ForEach(vm.infoDocs) { info in
+                        HeartbeatInfoRowItem(info: info)
+                    }
+                }
+                .listRowSeparator(.visible, edges: .top)
+                .listRowSeparatorTint(dividerColor)
             }
         }
         .onDisappear { vm.stopHeartbeat() }

--- a/Sources/DittoHeartbeat/HeartbeatView.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView.swift
@@ -70,7 +70,7 @@ public struct HeartbeatView: View {
         }
          */
     }
-    
+    /*
     @ViewBuilder
     func peerView(_ peer: DittoPeer, showBLEDistance: Bool = false) -> some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -116,4 +116,5 @@ public struct HeartbeatView: View {
             }
         }
     }
+     */
 }


### PR DESCRIPTION
The Heartbeat tool module, including a simple UI for displaying output of heartbeat docs.
    
- add heartbeat module to Package.swift
- add DittoHeartbeat lib Xcode scheme as embedded lib
- heartbeat feature implemented as HeartbeatVM servicing callback function
and infoPublisher, on timer configured with config param
- isEnabled property, and start and stop heartbeat functions
- refactor HeartbeatVM to normalize data output from the callback and to
    the (devices) collection
- add new output-related data classes/structs
- add HeartbeatView and related supporting structures and extensions to
visualize a list of heartbeat documents from the configured collection
- heartbeat get-started view: in HeartbeatView, if play status is paused and there are no docs   
in the PrivateHeartbeatVM infoDocs collection, "getting started" text is displayed along with   
a large play button.
