### PR TITLE
Fix Health Metrics properly emitting

### DIFF
--- a/Sources/DittoHeartbeat/HeartbeatModels.swift
+++ b/Sources/DittoHeartbeat/HeartbeatModels.swift
@@ -111,8 +111,8 @@ public extension DittoHeartbeatInfo {
 
     private func healthMetricsValue() -> [String: Any] {
         var healthMetricsVal = [String: Any]()
-        for healthMetric in healthMetrics {
-            healthMetricsVal[healthMetric.key] = healthMetric.value
+        for (metricName, metric) in healthMetrics {
+            healthMetricsVal[metricName] = metric.value
         }
         return healthMetricsVal
     }

--- a/Sources/DittoHeartbeat/HeartbeatModels.swift
+++ b/Sources/DittoHeartbeat/HeartbeatModels.swift
@@ -96,7 +96,8 @@ public extension DittoHeartbeatInfo {
             String.sdk: sdk,
             String.presenceSnapshotDirectlyConnectedPeersCount: presenceSnapshotDirectlyConnectedPeers.count,
             String.presenceSnapshotDirectlyConnectedPeers: connectionsValue(),
-            String.metadata: metadata
+            String.metadata: metadata,
+            String.healthMetrics: healthMetrics
         ]
     }
     

--- a/Sources/DittoHeartbeat/HeartbeatModels.swift
+++ b/Sources/DittoHeartbeat/HeartbeatModels.swift
@@ -97,7 +97,7 @@ public extension DittoHeartbeatInfo {
             String.presenceSnapshotDirectlyConnectedPeersCount: presenceSnapshotDirectlyConnectedPeers.count,
             String.presenceSnapshotDirectlyConnectedPeers: connectionsValue(),
             String.metadata: metadata,
-            String.healthMetrics: healthMetrics
+            String.healthMetrics: healthMetricsValue()
         ]
     }
     
@@ -107,6 +107,14 @@ public extension DittoHeartbeatInfo {
             cxVal[cx.peerKey] = cx.value
         }
         return cxVal
+    }
+
+    private func healthMetricsValue() -> [String: Any] {
+        var healthMetricsVal = [String: Any]()
+        for healthMetric in healthMetrics {
+            healthMetricsVal[healthMetric.key] = healthMetric.value
+        }
+        return healthMetricsVal
     }
 }
 
@@ -175,5 +183,12 @@ private extension HealthMetric {
             return nil
         }
         self.init(isHealthy: isHealthy, details: details)
+    }
+
+    var value: [String: Any] {
+        [
+            String.isHealthy: isHealthy,
+            String.details: details
+        ]
     }
 }

--- a/Sources/DittoHeartbeat/HeartbeatVM.swift
+++ b/Sources/DittoHeartbeat/HeartbeatVM.swift
@@ -63,13 +63,12 @@ public class HeartbeatVM: ObservableObject {
     }
 
     private func updateHealthMetrics() {
-        guard var hbInfo = hbInfo,
-            let hbConfig = hbConfig else { return }
+        guard let hbConfig = hbConfig else { return }
         var newHealthMetrics: [String: HealthMetric] = [:]
         hbConfig.healthMetricProviders.forEach { provider in
             newHealthMetrics[provider.metricName] = provider.getCurrentState()
         }
-        hbInfo.healthMetrics = newHealthMetrics
+        hbInfo?.healthMetrics = newHealthMetrics
     }
 
     private func startTimer() {

--- a/Sources/DittoPermissionsHealth/Constants.swift
+++ b/Sources/DittoPermissionsHealth/Constants.swift
@@ -6,6 +6,6 @@
 //
 
 struct DittoPermissionsHealthConstants {
-    static let networkManagerHealthMetricName = "DittoPermissionsHealth.WiFi"
-    static let bluetoothManagerHealthMetricName = "DittoPermissionsHealth.Bluetooth"
+    static let networkManagerHealthMetricName = "DittoPermissionsHealth_WiFi"
+    static let bluetoothManagerHealthMetricName = "DittoPermissionsHealth_Bluetooth"
 }


### PR DESCRIPTION
In 4.8.0, the HealthMetrics don't properly emit because of a shadowed var in `updateHealthMetrics()` 🤦 .

After fixing that, they _also_ didn't get attached to the Ditto collection in `emit()`, but they did show up in the Publisher and the callback closure

Also updates the `metricName`s used by the `DittoPermissionsHealth` tool to use underscores instead of period, making parsing the JSON representation of the resulting Ditto document easier