### PR TITLE
Remove macOS 11+ from Package.swift as the tools currently don't build for MacOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ let package = Package(
     name: "DittoSwiftTools",
     platforms: [
         .iOS(.v11),
-        .macOS(.v11),
     ],
     products: [
         .library(


### PR DESCRIPTION
Today, Package.swift lists support for MacOS 11+, but the tools don't actually build for MacOS, primarily due to use of UIKit in some tools. To reduce confusion, I'm removing the entry from Package.swift and logged #110 for supporting MacOS in the future (I'm also totally fine closing this and just fixing it with that issue)