### PR TITLE
Bump minimum iOS version to 14 instead of 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "DittoSwiftTools",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v14),
         .macOS(.v11),
     ],
     products: [

--- a/Sources/DittoDataBrowser/DataBrowser.swift
+++ b/Sources/DittoDataBrowser/DataBrowser.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import DittoSwift
 
-@available(iOS 14.0, *)
 public struct DataBrowser: View {
     
     @StateObject var viewModel: DataBrowserViewModel

--- a/Sources/DittoDataBrowser/DataBrowserViewModel.swift
+++ b/Sources/DittoDataBrowser/DataBrowserViewModel.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import DittoSwift
 
-@available(iOS 13.0, *)
 class DataBrowserViewModel: ObservableObject {
     
     @Published var collections: [DittoCollection]?

--- a/Sources/DittoDataBrowser/DocumentsViewModel.swift
+++ b/Sources/DittoDataBrowser/DocumentsViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 import DittoSwift
 import OrderedCollections
 
-@available(iOS 13.0, *)
 class DocumentsViewModel : ObservableObject {
     
     let collectionName: String

--- a/Sources/DittoDiskUsage/DittoDiskUsageView.swift
+++ b/Sources/DittoDiskUsage/DittoDiskUsageView.swift
@@ -24,7 +24,6 @@ fileprivate struct DiskUsageState {
     let error: String?
 }
 
-@available(iOS 14, *)
 class DiskUsageViewModel: ObservableObject {
 
     @Published fileprivate var diskUsage: DiskUsageState?
@@ -85,7 +84,6 @@ class DiskUsageViewModel: ObservableObject {
     }
 }
 
-@available(iOS 14, *)
 public struct DittoDiskUsageView: View {
 
     @Environment(\.presentationMode) var presentationMode
@@ -157,7 +155,6 @@ public struct DittoDiskUsageView: View {
     }
 }
 
-@available(iOS 14, *)
 struct DittoDiskUsageView_Previews: PreviewProvider {
     static var previews: some View {
         DittoDiskUsageView(ditto: Ditto())

--- a/Sources/DittoExportData/ExportData.swift
+++ b/Sources/DittoExportData/ExportData.swift
@@ -8,8 +8,6 @@ import SwiftUI
 import UIKit
 #endif
 
-
-@available(iOS 13.0, *)
 public struct ExportData: UIViewControllerRepresentable {
 
     private let ditto: Ditto

--- a/Sources/DittoExportLogs/ExportLogs.swift
+++ b/Sources/DittoExportLogs/ExportLogs.swift
@@ -8,8 +8,6 @@ import SwiftUI
 import UIKit
 #endif
 
-
-@available(iOS 13.0, *)
 public struct ExportLogs: UIViewControllerRepresentable {
     
     public init() {}

--- a/Sources/DittoHeartbeat/HeartbeatVM.swift
+++ b/Sources/DittoHeartbeat/HeartbeatVM.swift
@@ -15,7 +15,6 @@ import SwiftUI
 
 public typealias HeartbeatCallback = (DittoHeartbeatInfo) -> Void
 
-@available(iOS 13, *)
 public class HeartbeatVM: ObservableObject {
     @Published public var isEnabled = false
     private var hbConfig: DittoHeartbeatConfig?

--- a/Sources/DittoPeersList/DittoPeer+Extensions.swift
+++ b/Sources/DittoPeersList/DittoPeer+Extensions.swift
@@ -9,7 +9,6 @@ import Foundation
 import DittoSwift
 import CryptoKit
 
-@available(iOS 13.0, *)
 extension DittoPeer {
     var peerSDKVersion: String {
         let sdk = "SDK "

--- a/Sources/DittoPermissionsHealth/BluetoothManager.swift
+++ b/Sources/DittoPermissionsHealth/BluetoothManager.swift
@@ -10,7 +10,6 @@ import CoreBluetooth
 import DittoHealthMetrics
 import Foundation
 
-@available(iOS 13.0, *)
 public class BluetoothManager: NSObject, ObservableObject {
     private var centralManager: CBCentralManager!
     private var cancellables = Set<AnyCancellable>()
@@ -82,7 +81,6 @@ public class BluetoothManager: NSObject, ObservableObject {
     }
 }
 
-@available(iOS 13.0, *)
 extension BluetoothManager: CBCentralManagerDelegate {
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         // This delegate method is called when there's a change in the manager's state.
@@ -90,7 +88,6 @@ extension BluetoothManager: CBCentralManagerDelegate {
     }
 }
 
-@available(iOS 13.0, *)
 extension BluetoothManager: HealthMetricProvider {
     public var metricName: String {
         DittoPermissionsHealthConstants.bluetoothManagerHealthMetricName

--- a/Sources/DittoPermissionsHealth/NetworkManager.swift
+++ b/Sources/DittoPermissionsHealth/NetworkManager.swift
@@ -9,7 +9,6 @@ import Combine
 import DittoHealthMetrics
 import Network
 
-@available(iOS 13.0, *)
 public class NetworkManager: NSObject, ObservableObject {
     @Published var isWifiEnabled = false
 
@@ -30,7 +29,6 @@ public class NetworkManager: NSObject, ObservableObject {
     }
 }
 
-@available(iOS 13.0, *)
 extension NetworkManager: HealthMetricProvider {
     public var metricName: String {
         DittoPermissionsHealthConstants.networkManagerHealthMetricName

--- a/Sources/DittoPermissionsHealth/PermissionsHealth.swift
+++ b/Sources/DittoPermissionsHealth/PermissionsHealth.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14.0, *)
 public struct PermissionsHealth: View {
     @ObservedObject var bluetoothManager = BluetoothManager()
     @ObservedObject var networkManager = NetworkManager()

--- a/Sources/DittoPresenceDegradation/NewSessionView.swift
+++ b/Sources/DittoPresenceDegradation/NewSessionView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 public struct NewSessionView: View {
     
     @Binding private var expectedPeers: Int

--- a/Sources/DittoPresenceDegradation/PresenceDegradationVM.swift
+++ b/Sources/DittoPresenceDegradation/PresenceDegradationVM.swift
@@ -10,7 +10,6 @@ import DittoSwift
 import CryptoKit
 import Combine
 
-@available(iOS 13.0, *)
 class PresenceDegradationVM: ObservableObject {
         
     @Published var expectedPeers: Int = 0

--- a/Sources/DittoPresenceDegradation/PresenceDegradationView.swift
+++ b/Sources/DittoPresenceDegradation/PresenceDegradationView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import DittoSwift
 
-@available(iOS 14.0, *)
 public struct PresenceDegradationView: View {
     
     @StateObject var vm: PresenceDegradationVM

--- a/Sources/DittoPresenceViewer/PresenceView.swift
+++ b/Sources/DittoPresenceViewer/PresenceView.swift
@@ -19,7 +19,7 @@ import UIKit
 import AppKit
 #endif
 
-@available(iOS 13, macOS 10.15, *)
+@available(macOS 10.15, *)
 public struct PresenceView: View {
     public var ditto: Ditto
 
@@ -34,7 +34,6 @@ public struct PresenceView: View {
 
 // MARK: - UIViewRepresentable
 #if os(iOS)
-@available(iOS 13, *)
 extension PresenceView: UIViewRepresentable {
     public typealias Body = Never
     public typealias UIViewType = UIView


### PR DESCRIPTION
The 4.5 release of the Ditto SDK upped the minimum required iOS version from 11 to 14, this updates DittoSwiftTools to align to that same minimum