### PR TITLE
Don't consider iPhone simulator to have unhealthy bluetooth

### DIFF
--- a/Sources/DittoPermissionsHealth/BluetoothManager.swift
+++ b/Sources/DittoPermissionsHealth/BluetoothManager.swift
@@ -73,7 +73,11 @@ public class BluetoothManager: NSObject, ObservableObject {
     }
 
     var isHealthy: Bool {
+#if targetEnvironment(simulator)
+        authorizationStatus == .allowedAlways // The simulator always reports Unsupported but should still be considered healthy
+#else
         managerState == .poweredOn && authorizationStatus == .allowedAlways
+#endif
     }
 
     var healthDetails: [String: String] {

--- a/Sources/DittoPermissionsHealth/BluetoothManager.swift
+++ b/Sources/DittoPermissionsHealth/BluetoothManager.swift
@@ -60,7 +60,11 @@ public class BluetoothManager: NSObject, ObservableObject {
         case .resetting:
             return "Resetting"
         case .unsupported:
+#if targetEnvironment(simulator)
+            return "Unsupported (Simulator)"
+#else
             return "Unsupported"
+#endif
         case .unauthorized:
             return "Unauthorized"
         case .poweredOff:


### PR DESCRIPTION
Don't flag iOS Simulators as automatically unhealthy because bluetooth is unsupported