### PR TITLE
Allow heartbeat tool to not publish to collection if users want to only utilize the custom callbacks.

### DIFF
--- a/Sources/DittoHeartbeat/HeartbeatModels.swift
+++ b/Sources/DittoHeartbeat/HeartbeatModels.swift
@@ -15,12 +15,18 @@ public struct DittoHeartbeatConfig {
     public var secondsInterval: Int
     public var metadata: [String: Any]?
     public var healthMetricProviders: [HealthMetricProvider]
+    public var publishToDittoCollection: Bool
 
-    public init(id: String, secondsInterval: Int, metadata: [String : Any]? = nil, healthMetricProviders: [HealthMetricProvider] = []) {
+    public init(id: String,
+                secondsInterval: Int,
+                metadata: [String : Any]? = nil,
+                healthMetricProviders: [HealthMetricProvider] = [],
+                publishToDittoCollection: Bool = true) {
         self.id = id
         self.secondsInterval = secondsInterval
         self.metadata = metadata
         self.healthMetricProviders = healthMetricProviders
+        self.publishToDittoCollection = publishToDittoCollection
     }
 }
 

--- a/Sources/DittoHeartbeat/HeartbeatVM.swift
+++ b/Sources/DittoHeartbeat/HeartbeatVM.swift
@@ -117,6 +117,7 @@ public class HeartbeatVM: ObservableObject {
     }
     
     private func updateCollection() {
+        guard hbConfig?.publishToDittoCollection == true else { return }
         guard let doc = hbInfo?.value else {
             print("DittoHeartbeatVM.\(#function): ERROR updatingCollection: bhInfo is NIL --> Return")
             return


### PR DESCRIPTION
Some customers may want to customize the tool so that it doesn't publish the heartbeat data as a Ditto collection, but instead pipe that data via a custom callback to somewhere else.

This adds a new configuration flag `publishToDittoCollection` which defaults to true.

Closes #113 