### PR TITLE
Remove heartbeat subscription

### DIFF
--- a/Sources/DittoHeartbeat/HeartbeatVM.swift
+++ b/Sources/DittoHeartbeat/HeartbeatVM.swift
@@ -20,7 +20,6 @@ public class HeartbeatVM: ObservableObject {
     private var hbConfig: DittoHeartbeatConfig?
     private var hbInfo: DittoHeartbeatInfo?
     private var hbCallback: HeartbeatCallback?
-    private var hbSubscription: DittoSyncSubscription?
     private var ditto: Ditto
     private var peers = [DittoPeer]()
     private var peersObserver: DittoSwift.DittoObserver?
@@ -50,17 +49,12 @@ public class HeartbeatVM: ObservableObject {
         )
         observePeers()
         startTimer()
-
-        if config.publishToDittoCollection {
-            hbSubscription = try? ditto.sync.registerSubscription(query: "SELECT * FROM \(String.collectionName)")
-        }
     }
     
     public func stopHeartbeat() {
         stopTimer()
         isEnabled = false
         peersObserver?.stop()
-        hbSubscription?.cancel()
     }
 
     private func updateHealthMetrics() {


### PR DESCRIPTION
Don't default the heartbeat tool to subscribe to the devices collection. This will be opt-in with narrower subscriptions as needed to allow multi-hop for a given location/group without syncing uneeded data between locations.

Closes #121 