### PR TITLE
Update minimum Ditto SDK version from 4.7.0 to 4.8.0

### DIFF
--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.pbxproj
@@ -787,7 +787,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.7.0;
+				minimumVersion = 4.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DittoToolsApp/DittoToolsApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DittoToolsApp/DittoToolsApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "87b0dd1c4a9bcbe2ae45ce3ad5975c152878b3ea",
-        "version" : "4.7.4"
+        "revision" : "fb4ee210d85380084f9bdd26cd5bb987db971da2",
+        "version" : "4.8.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,17 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "87b0dd1c4a9bcbe2ae45ce3ad5975c152878b3ea",
-        "version" : "4.7.4"
+        "revision" : "fb4ee210d85380084f9bdd26cd5bb987db971da2",
+        "version" : "4.8.0"
       }
     },
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "07e47b1e93e5a1e0ef0c50fcb2d6739fb6be4003",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
+      "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "07e47b1e93e5a1e0ef0c50fcb2d6739fb6be4003",
-        "version" : "1.0.0"
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.8.1
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
             targets: ["DittoAllToolsMenu"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.7.0"),
+        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.8.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
Updates the Ditto SDK minimum version from 4.7.0 to 4.8.0 in both the DittoSwiftTools package and the DittoToolsApp project

This will unblock 2 ongoing efforts:
1. https://github.com/getditto/DittoSwiftTools/pull/82
2. https://github.com/getditto/DittoSwiftTools/issues/137

This will mean the next release of DittoSwiftTools includes a major version bump to 6.0.0.