### PR TITLE
Fix deprecation warning in BluetoothManager

### DIFF
--- a/Sources/DittoAllToolsMenu/DittoManager.swift
+++ b/Sources/DittoAllToolsMenu/DittoManager.swift
@@ -31,7 +31,7 @@ class DittoManager: ObservableObject {
         // subscribe to loggingOption changes
         // make sure log level is set _before_ starting ditto
         $loggingOption
-            .sink { [weak self] logOption in
+            .sink { logOption in
                 switch logOption {
                 case .disabled:
                     DittoLogger.enabled = false

--- a/Sources/DittoPermissionsHealth/BluetoothManager.swift
+++ b/Sources/DittoPermissionsHealth/BluetoothManager.swift
@@ -12,29 +12,13 @@ import Foundation
 
 public class BluetoothManager: NSObject, ObservableObject {
     private var centralManager: CBCentralManager!
-    private var cancellables = Set<AnyCancellable>()
 
-    @Published var authorizationStatus: CBManagerAuthorization = .notDetermined
+    @Published var authorizationStatus: CBManagerAuthorization = CBCentralManager.authorization
     @Published var managerState: CBManagerState = .unknown
 
     public override init() {
         super.init()
-
         centralManager = CBCentralManager(delegate: self, queue: nil)
-
-        // Watch for changes in authorization status
-        centralManager.publisher(for: \.authorization)
-            .sink { [weak self] authorization in
-                self?.authorizationStatus = authorization
-            }
-            .store(in: &cancellables)
-
-        // Watch for changes in manager state
-        centralManager.publisher(for: \.state)
-            .sink { [weak self] state in
-                self?.managerState = state
-            }
-            .store(in: &cancellables)
     }
 
     var authorizationStatusDescription: String {
@@ -91,8 +75,8 @@ public class BluetoothManager: NSObject, ObservableObject {
 
 extension BluetoothManager: CBCentralManagerDelegate {
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        // This delegate method is called when there's a change in the manager's state.
-        // We don't need to do anything here since we're observing the state using Combine.
+        self.managerState = central.state
+        self.authorizationStatus = CBCentralManager.authorization
     }
 }
 


### PR DESCRIPTION
Updates `BluetoothManager` to fully utilize its existing conformance to `CBCentralManagerDelegate` and use that delegate conformance to get updates about both authorization status and bluetooth state. Previously, this used Combine to access the `state` and `authorization` properties on the local instance of `CBCentralManager`, but in iOS 13.1, `authorization` moved to be a class property instead.

Also removes an unused `[weak self]` from `DittoManager.swift`

Closes #136