### PR TITLE
Update all tools to not require iOS 15 anywhere

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 
 import PackageDescription
 

--- a/Sources/DittoAllToolsMenu/AllToolsMenu.swift
+++ b/Sources/DittoAllToolsMenu/AllToolsMenu.swift
@@ -9,7 +9,6 @@ import DittoSwift
 import SwiftUI
 import DittoExportLogs
 
-@available(iOS 15.0, *)
 public struct AllToolsMenu: View {
     @Environment(\.colorScheme) private var colorScheme
 
@@ -77,17 +76,19 @@ public struct AllToolsMenu: View {
             }
             .listStyle(InsetGroupedListStyle())
             .navigationTitle("Ditto Tools")
-            .alert("Export Ditto Directory", isPresented: $presentExportDataAlert) {
-                Button("Export") {
-                    presentExportDataShare = true
-                }
-                Button("Cancel", role: .cancel) {}
-
-                } message: {
-                    Text("Compressing the data may take a while.")
-                }
+            .alert(isPresented: $presentExportDataAlert) {
+                Alert(title: Text("Export Ditto Directory"),
+                      message: Text("Compressing the data may take a while."),
+                      primaryButton: .default(
+                        Text("Export"),
+                        action: {
+                            presentExportDataShare = true
+                        }),
+                      secondaryButton: .cancel()
+                )
             }
-            
+        }
+
         .navigationViewStyle(StackNavigationViewStyle())
         VStack {
             Text("SDK Version: \(DittoManager.shared.ditto?.sdkVersion ?? "N/A")")

--- a/Sources/DittoAllToolsMenu/Pages/HeartBeatViewer.swift
+++ b/Sources/DittoAllToolsMenu/Pages/HeartBeatViewer.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import DittoHeartbeat
 
-@available(iOS 15, *)
 struct HeartBeatViewer: View {
     var body: some View {
         HeartbeatView(ditto: DittoManager.shared.ditto!)

--- a/Sources/DittoAllToolsMenu/Pages/LoggingDetailsViewer.swift
+++ b/Sources/DittoAllToolsMenu/Pages/LoggingDetailsViewer.swift
@@ -10,7 +10,6 @@ import DittoExportLogs
 import DittoSwift
 import SwiftUI
 
-@available(iOS 15, *)
 struct LoggingDetailsViewer: View {
     @ObservedObject var dittoManager = DittoManager.shared
     
@@ -19,7 +18,6 @@ struct LoggingDetailsViewer: View {
     }
 }
 
-@available(iOS 15, *)
 struct LoggingDetailsViewer_Previews: PreviewProvider {
     static var previews: some View {
         LoggingDetailsViewer(dittoManager: DittoManager.shared)

--- a/Sources/DittoAllToolsMenu/Pages/PeersListViewer.swift
+++ b/Sources/DittoAllToolsMenu/Pages/PeersListViewer.swift
@@ -10,7 +10,6 @@ import DittoPeersList
 import DittoDiskUsage
 import SwiftUI
 
-@available(iOS 15, *)
 struct PeersListViewer: View {
 
     var body: some View {

--- a/Sources/DittoDataBrowser/Documents.swift
+++ b/Sources/DittoDataBrowser/Documents.swift
@@ -17,7 +17,6 @@ struct Documents: View {
     
     @StateObject var viewModel: DocumentsViewModel
     @State var querySearch = ""
-//    @State var selectedDoc = ""
         
     init(collectionName: String, ditto: Ditto, isStandAlone: Bool) {
         self._viewModel = StateObject(wrappedValue: DocumentsViewModel(collectionName: collectionName, ditto: ditto, isStandAlone: isStandAlone))

--- a/Sources/DittoDataBrowser/Documents.swift
+++ b/Sources/DittoDataBrowser/Documents.swift
@@ -12,7 +12,6 @@ import DittoSwift
 import UIKit
 #endif
 
-@available(iOS 15.0, *)
 struct Documents: View {
     
     @StateObject var viewModel: DocumentsViewModel
@@ -61,7 +60,6 @@ struct Documents: View {
 
                 Divider()
                     .frame(height: 4)
-                    .overlay(.gray)
                     .padding(.bottom)
 
             
@@ -100,15 +98,7 @@ struct Documents: View {
     }
 }
 
-//struct Documents_Previews: PreviewProvider {
-//    static var previews: some View {
-//        Documents(collectionName: "Default")
-//    }
-//}
-
-@available(iOS 15.0, *)
 struct SearchBar: View {
-    
     @Binding var searchText: String
     @ObservedObject var viewModel: DocumentsViewModel
         

--- a/Sources/DittoExportLogs/LoggingDetailsView.swift
+++ b/Sources/DittoExportLogs/LoggingDetailsView.swift
@@ -10,8 +10,6 @@ import Combine
 import DittoSwift
 import SwiftUI
 
-
-@available(iOS 15, *)
 public struct LoggingDetailsView: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var presentExportLogsShare: Bool = false
@@ -59,19 +57,21 @@ public struct LoggingDetailsView: View {
             }
         }
         .listStyle(InsetGroupedListStyle())
-        .alert("Export Logs", isPresented: $presentExportLogsAlert) {
-            Button("Export") {
-                presentExportLogsShare = true
-            }
-            Button("Cancel", role: .cancel) {}
-
-        } message: {
-            Text("Compressing the logs may take a few seconds.")
+        .alert(isPresented: $presentExportLogsAlert) {
+            Alert(title:
+                    Text("Export Logs"),
+                  message:
+                    Text("Compressing the logs may take a few seconds."),
+                  primaryButton:
+                    .default(Text("Export"),action: {
+                        presentExportLogsShare = true
+                    }),
+                  secondaryButton: .cancel()
+            )
         }
     }
 }
 
-@available(iOS 15, *)
 struct LoggingDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         LoggingDetailsView(loggingOption: .constant(.debug))

--- a/Sources/DittoExportLogs/LoggingDetailsView.swift
+++ b/Sources/DittoExportLogs/LoggingDetailsView.swift
@@ -58,12 +58,11 @@ public struct LoggingDetailsView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .alert(isPresented: $presentExportLogsAlert) {
-            Alert(title:
-                    Text("Export Logs"),
-                  message:
-                    Text("Compressing the logs may take a few seconds."),
-                  primaryButton:
-                    .default(Text("Export"),action: {
+            Alert(title: Text("Export Logs"),
+                  message: Text("Compressing the logs may take a few seconds."),
+                  primaryButton: .default(
+                    Text("Export"),
+                    action: {
                         presentExportLogsShare = true
                     }),
                   secondaryButton: .cancel()

--- a/Sources/DittoHeartbeat/HeartbeatView+Extensions.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView+Extensions.swift
@@ -10,7 +10,6 @@ import DittoSwift
 import SwiftUI
 
 //MARK: View Extensions
-@available(iOS 15, *)
 
 public struct HeartbeatInfoView: View {
     let info: DittoHeartbeatInfo
@@ -36,7 +35,6 @@ public struct HeartbeatInfoView: View {
     }
 }
 
-@available(iOS 15, *)
 public struct HeartbeatInfoRowItem: View {
     let info: DittoHeartbeatInfo
     public var body: some View {
@@ -47,7 +45,6 @@ public struct HeartbeatInfoRowItem: View {
 
 
 //MARK: Heartbeat Model View Extension
-@available(iOS 15, *)
 
 public extension DittoHeartbeatInfo {
     
@@ -74,7 +71,6 @@ public extension DittoHeartbeatInfo {
 
 
 //MARK: Heartbeat Model PeerConnection Extension
-@available(iOS 15, *)
 
 extension DittoPeerConnection: CustomStringConvertible {
 

--- a/Sources/DittoHeartbeat/HeartbeatView.swift
+++ b/Sources/DittoHeartbeat/HeartbeatView.swift
@@ -10,8 +10,6 @@ import Combine
 import DittoSwift
 import SwiftUI
 
-
-@available(iOS 15, *)
 private class PrivateHeartbeatVM: ObservableObject {
     @Published private(set) var infoDocs = [DittoHeartbeatInfo]()
     @Published fileprivate var isPaused = true
@@ -71,7 +69,6 @@ private class PrivateHeartbeatVM: ObservableObject {
     }
 }
 
-@available(iOS 15, *)
 public struct HeartbeatView: View {
     @StateObject fileprivate var vm: PrivateHeartbeatVM
     private let dividerColor: Color = .accentColor
@@ -94,7 +91,6 @@ public struct HeartbeatView: View {
                         vm.isPaused.toggle()
                     }, label: {
                         Image(systemName: String.imgPlay)
-                            .symbolRenderingMode(.multicolor)
                             .font(.system(size: 60))
                     })
                     
@@ -104,7 +100,6 @@ public struct HeartbeatView: View {
                 List {
                     ForEach(vm.infoDocs) { info in
                         HeartbeatInfoRowItem(info: info)
-                            .listRowSeparatorTint(dividerColor)
                     }
                 }
             }
@@ -117,7 +112,6 @@ public struct HeartbeatView: View {
                     vm.isPaused.toggle()
                 } label: {
                     Image(systemName: vm.isPaused ? String.imgPlay : String.imgPause)
-                        .symbolRenderingMode(.multicolor)
                 }
                 .font(.system(size: 24))
                 .foregroundColor(.accentColor)

--- a/Sources/DittoPeersList/PeersListView.swift
+++ b/Sources/DittoPeersList/PeersListView.swift
@@ -9,7 +9,6 @@
 import DittoSwift
 import SwiftUI
 
-@available(iOS 15, *)
 public struct PeersListView: View {
     @StateObject var vm: PeersObserverVM
     private let dividerColor: Color
@@ -33,15 +32,11 @@ public struct PeersListView: View {
             } footer: {
                 Text(Self.footerText)
             }
-            .listRowSeparator(.visible, edges: .top)
-            .listRowSeparatorTint(dividerColor)
             
             Section {
                 ForEach(vm.peers, id: \.peerKey) { peer in
                     peerView(peer)
                         .padding(.bottom, 4)
-                        .listRowSeparator(.visible, edges: .top)
-                        .listRowSeparatorTint(dividerColor)
                 }
             } header: {
                 Text("Remote Peers")
@@ -59,7 +54,6 @@ public struct PeersListView: View {
                     vm.isPaused.toggle()
                 } label: {
                     Image(systemName: vm.isPaused ? "play.circle" : "pause.circle")
-                        .symbolRenderingMode(.multicolor)
                 }
                 .font(.system(size: 24))
                 .foregroundColor(.accentColor)
@@ -81,8 +75,6 @@ public struct PeersListView: View {
                     VStack(alignment: .leading) {
                         Divider()
                             .frame(height: 1)
-                            .overlay(.gray).opacity(0.4)
-                        
                         Text("peer: \(conPeer.peerKeyString)")
                             .lineLimit(1)
                             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/DittoPeersList/PeersObserverVM.swift
+++ b/Sources/DittoPeersList/PeersObserverVM.swift
@@ -11,7 +11,6 @@ import DittoSwift
 import SwiftUI
 import Foundation
 
-@available(iOS 15, *)
 @MainActor public class PeersObserverVM: ObservableObject {
     @Published var peers: [DittoPeer]
     @Published var localPeer: DittoPeer


### PR DESCRIPTION
Updates all of DittoSwiftTools to work on iOS 14 as advertised by our Package.swift.

Closes #109

Note - I did not update the DittoToolsApp in the repository; only the tools that are in the package. Updating the app itself would require reducing the deployment target of that app from its current 15.5 down to 14.0.