### PR TITLE
Update Ditto SDK dependency to 4.9.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
             targets: ["DittoAllToolsMenu"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.8.0"),
+        .package(url: "https://github.com/getditto/DittoSwiftPackage", from: "4.9.1"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
Updates the Ditto SDK minimum version to 4.9.1 to avoid an iOS 18 crash and a retain cystle in the disk usage system used by the Disk Usage tool.