### PR TITLE
Fixed interactive dismissal and Identity type modal for macOS

### DIFF
--- a/DittoToolsApp/DittoToolsApp/Views/Credentials View/Components/FormField.swift
+++ b/DittoToolsApp/DittoToolsApp/Views/Credentials View/Components/FormField.swift
@@ -122,6 +122,7 @@ struct FormField: View {
     @ViewBuilder
     private func clearableTextField(subtype: FormFieldType.TextSubtype) -> some View {
         HStack {
+            #if !os(macOS)
             TextField(
                 placeholder ?? placeholderText(for: type) ?? "",
                 text: $stringValue,
@@ -129,16 +130,22 @@ struct FormField: View {
                     isTextFieldFocused = isEditing
                 }
             )
-            #if !os(macOS)
             .keyboardType(type.keyboardType)
-            #endif
-            .autocorrectionDisabled()
-            #if !os(macOS)
             .autocapitalization(subtype == .uuid ? .allCharacters : .none)
             .font(.system(.body, design: .monospaced))
-            #endif
+            .autocorrectionDisabled()
             .multilineTextAlignment(textAlignment)
-
+            #else
+            TextField(
+                text: $stringValue,
+                prompt: Text(placeholder ?? placeholderText(for: type) ?? "")
+            ) {
+                Text("")
+            }
+            .autocorrectionDisabled()
+            .multilineTextAlignment(textAlignment)
+            #endif
+            
             #if !os(tvOS)
             Image(systemName: "xmark.circle.fill")
             #if !os(macOS)

--- a/DittoToolsApp/DittoToolsApp/Views/Credentials View/CredentialsView.swift
+++ b/DittoToolsApp/DittoToolsApp/Views/Credentials View/CredentialsView.swift
@@ -41,6 +41,7 @@ struct CredentialsView: View {
         }
         .onAppear { disableInteractiveDismissal() }
         #if os(macOS)
+        .onDisappear { enableInteractiveDismissal() }
         .alert("Cannot Apply Credentials", isPresented: $isShowingValidationErrorAlert) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -54,7 +55,7 @@ struct CredentialsView: View {
         } message: {
             Text("This will permanently delete your saved credentials.")
         }
-        #else
+        #elseif os(iOS)
         .actionSheet(isPresented: $isShowingConfirmClearCredentials) {
             clearCredentialsActionSheet
         }
@@ -92,6 +93,8 @@ struct CredentialsView: View {
             }
         #elseif os(macOS)
             formView
+            .frame(minWidth: 500, minHeight: 300)
+            .padding(20)
         #else
             formView
                 .navigationBarTitleDisplayMode(.inline)
@@ -210,6 +213,15 @@ struct CredentialsView: View {
         if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let rootVC = scene.windows.first?.rootViewController?.presentedViewController {
             rootVC.isModalInPresentation = true
+        }
+        #endif
+    }
+    
+    private func enableInteractiveDismissal() {
+        #if os(macOS)
+        if let window = NSApplication.shared.windows.first {
+            window.isMovable = true
+            window.styleMask.insert(.closable) // Enables the close button
         }
         #endif
     }

--- a/DittoToolsApp/DittoToolsApp/Views/Credentials View/Form/FormView.swift
+++ b/DittoToolsApp/DittoToolsApp/Views/Credentials View/Form/FormView.swift
@@ -73,23 +73,30 @@ struct FormView<ApplyButton: View, CancelButton: View, ClearButton: View>: View 
     }
 
     // MARK: - Identity Type Picker Section
+    
+    /// MacOS and iOS handle Picker title placement differently, conditionally displaying for uniformity across platforms
+    private var pickerLabel: String {
+        #if os(macOS)
+        return ""
+        #else
+        return "Identity Type"
+        #endif
+    }
 
     /// A section displaying the identity type picker, allowing users to choose the type of credentials to configure.
     private var identityTypePickerSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Section(header: Text("Identity Type")) {
-                Picker("Type", selection: $viewModel.formState.identityType) {
-                    ForEach(DittoIdentity.identityTypes, id: \.self) { type in
-                        Text(type.rawValue)
-                    }
+        VStack(alignment: .leading) {
+            #if os(macOS)
+            Text("Identity Type")
+            #endif
+            Picker(pickerLabel, selection: $viewModel.formState.identityType) {
+                ForEach(DittoIdentity.identityTypes, id: \.self) { type in
+                    Text(type.rawValue)
                 }
             }
-            #if os(macOS)
-            .padding(.bottom, 15)
-            #endif
         }
         #if os(macOS)
-        .padding(.top, 25)
+        .padding()
         #endif
     }
 
@@ -101,7 +108,6 @@ struct FormView<ApplyButton: View, CancelButton: View, ClearButton: View>: View 
     @ViewBuilder
     private var identityDetailsSection: some View {
         Section(
-            header: Text("Identity Details"),
             footer: Text("Applying these credentials will restart the Ditto sync engine.")
                 .font(.subheadline)
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
Fix to CXTOOLS-427

- Added enableInteractiveDismissal to CredentialsView on macOS
- Altered clearableTextField to have placeholder be in the input on macOS
- Added window min size and padding to formView on macOS
- Changed Picker title implementation on both macOS and iOS for consistency and cleanliness

<img width="1133" alt="Screenshot 2025-05-15 at 4 04 22 PM" src="https://github.com/user-attachments/assets/415ecf37-54bf-49e7-a538-a6728439c896" />
<img width="1133" alt="Screenshot 2025-05-15 at 2 55 29 PM" src="https://github.com/user-attachments/assets/a1271d1a-d648-468f-b1ca-e3234807b6dc" />
<img width="568" alt="Screenshot 2025-05-15 at 4 03 42 PM" src="https://github.com/user-attachments/assets/a199ebaf-d24c-4e28-990e-69d3d9fe69cb" />
<img width="568" alt="Screenshot 2025-05-15 at 4 06 43 PM" src="https://github.com/user-attachments/assets/06f528e8-eff4-4dbd-89f2-0bcffbd5ece9" />
